### PR TITLE
ci(dependabot): split groups by type/risk and add ecosystem tag to bilingual body

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,27 @@ updates:
       interval: "weekly"
       day: "monday"
       timezone: "Asia/Shanghai"
-    # 聚合小版本更新到单个 PR，减少噪音 / Group minor/patch updates into a single PR
+    # 按依赖类型与风险拆分分组，减少审查噪音 / Split groups by dependency type and risk
     groups:
-      minor-and-patch:
+      # 运行时依赖（http、sqflite 等）的 minor/patch 合并到一个 PR
+      # Runtime deps (http, sqflite, ...) minor/patch grouped into one PR
+      pub-runtime:
+        dependency-type: "direct:production"
         update-types:
           - "minor"
           - "patch"
-    # 大版本单独 PR，便于审查 / Major versions in separate PRs for careful review
+      # 开发依赖（flutter_lints 等）单独一组，更新频率与风险不同
+      # Dev deps (flutter_lints, ...) in their own group
+      pub-dev:
+        dependency-type: "direct:development"
+        update-types:
+          - "minor"
+          - "patch"
+      # 大版本始终单独 PR，便于仔细审查破坏性改动
+      # Major versions always standalone for careful breaking-change review
+      pub-major:
+        update-types:
+          - "major"
     open-pull-requests-limit: 5
     # 版本约束策略：保留既有 caret(^) 风格，仅提升版本号 / Preserve caret style, bump version only
     versioning-strategy: "increase"
@@ -46,10 +60,22 @@ updates:
       interval: "monthly"
       timezone: "Asia/Shanghai"
     groups:
-      minor-and-patch:
+      # example 运行时依赖 minor/patch 合并 / Example runtime deps minor/patch grouped
+      example-runtime:
+        dependency-type: "direct:production"
         update-types:
           - "minor"
           - "patch"
+      # example 开发依赖单独一组 / Example dev deps in own group
+      example-dev:
+        dependency-type: "direct:development"
+        update-types:
+          - "minor"
+          - "patch"
+      # example 大版本单独 PR / Example major versions standalone
+      example-major:
+        update-types:
+          - "major"
     # 每月最多提 1 个 PR，example 通常数月才会真正有版本变动 → 实际合并频率远低于 monthly
     # Max 1 PR per month; example deps rarely bump monthly → effective merge rate is far lower
     open-pull-requests-limit: 1

--- a/.github/workflows/dependabot-pr-bilingual.yml
+++ b/.github/workflows/dependabot-pr-bilingual.yml
@@ -43,6 +43,16 @@ jobs:
               return;
             }
 
+            // Derive the ecosystem label from the PR's labels so reviewers can
+            // tell at a glance which stack this bump touches.
+            // 根据 PR 的 label 推断生态，便于一眼识别本次更新属于哪个栈。
+            const labelNames = (pr.labels || []).map((l) => l.name);
+            const eco = labelNames.includes('github-actions')
+              ? 'GitHub Actions'
+              : labelNames.includes('example')
+                ? 'Example app (Dart/Flutter)'
+                : 'Dart/Flutter (pub)';
+
             const bilingual = `
 
 ${marker}
@@ -60,6 +70,12 @@ This automated dependency update was opened by Dependabot.
 - For \`pub\` dependencies, confirm the caret (\`^\`) constraint is preserved. / \`pub\` 依赖请确认仍保留 caret（\`^\`）约束。
 
 <sub>Auto-added by the Dependabot PR Bilingual Body workflow. / 由工作流自动追加。</sub>
+
+### Ecosystem / 生态
+
+This update affects the **${eco}** stack.
+
+本次更新涉及 **${eco}** 生态。
 `;
 
             const newBody = (pr.body || '') + bilingual;


### PR DESCRIPTION
## Summary / 摘要

- **方案1（主）**：将 `dependabot.yml` 中 pub 根项目与 example 的单一分组，按依赖类型与风险拆分为三档：`runtime`（运行时依赖 minor/patch）、`dev`（开发依赖 minor/patch）、`major`（大版本始终单独 PR），减少审查噪音。`github-actions` 保持原有 `all-actions` 分组不变。
- **方案2（辅）**：在 `dependabot-pr-bilingual.yml` 现有双语审查清单后，新增幂等的 `### Ecosystem / 生态` 标记，根据 PR label 自动标注本次更新所属栈（GitHub Actions / Example app / Dart-Flutter pub）。
- 未改动现有双语 workflow 的触发条件、权限与幂等逻辑，仅在 body 末尾追加一行。

## Why / 目的

- 之前 `http` 与 `flutter_lints` 等运行时/开发依赖混在同一 PR，难以区分；拆分后按类型与风险分组，review 更聚焦。
- 生态标记让维护者一眼识别 Dependabot PR 影响的栈，无需点进 diff。

## Test plan / 验证

- [x] `dependabot.yml` 结构人工校验，缩进与 groups 配置正确。
- [x] 现有双语 workflow 逻辑保持不变，仅追加生态 block，幂等 marker 沿用。
- [ ] Dependabot 下一轮更新周期生效（已开的旧 PR 不会按新分组重排）。

🤖 Generated with [ZeroBuddy](https://www.zerolabsco.com)
