### PR TITLE
fix(interceptors): harden interceptors against OOM, overwritten error reporters, and concurrent request mismatch (v1.2.2)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,7 +43,6 @@ jobs:
             --timeout 20
             --retry-wait-time 2
             --max-retries 2
-            --exclude-mail
             README.md README_zh.md CHANGELOG.md "docs/**"
           fail: true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.2.2
+
+> **🔔 推荐升级 / Upgrade recommended：** 本版本修复了拦截器的若干健壮性问题（大响应体 OOM、第三方错误上报被覆盖、并发同 URL 请求错乱），并修复了 example 依赖无法解析的问题。
+> This release fixes several interceptor robustness issues (large-response OOM, overwritten third-party error reporting, concurrent same-URL request mis-association) and an unresolvable example dependency.
+
+本版本提升了拦截器在与网络请求、错误捕获交互时的健壮性，并修正了 example 工程的可解析性。
+This release improves interceptor robustness for network requests and error capture, and fixes the example project's resolvability.
+
+**修复 / Bug Fixes:**
+
+- 拦截器健壮性修复 / Interceptor robustness fixes
+  - HTTP 拦截器：捕获的响应体上限设为 512KB，避免下载大文件时内存溢出（OOM）
+  - HTTP interceptor: cap captured response body at 512KB to avoid OOM on large downloads
+  - 日志拦截器：保留并恢复原始的 `FlutterError.onError`，不再覆盖 Crashlytics / Sentry 等第三方错误上报
+  - Log interceptor: preserve and restore the original `FlutterError.onError` so third-party reporters (Crashlytics/Sentry) are no longer overwritten
+  - Dio 拦截器：响应/错误匹配优先使用 `x-inspector-request-id`，回退到 URL，避免并发同 URL 请求错乱配对
+  - Dio interceptor: match responses/errors by `x-inspector-request-id` first, falling back to URL, to avoid mis-associating concurrent same-URL requests
+- 构建修复 / Build fix
+  - example 的 `dio` 依赖由不存在的 `5.11.0` 固定为 `5.4.0`，修复 `flutter pub get` 解析失败
+  - Pinned example `dio` from the non-existent `5.11.0` to `5.4.0`, fixing `flutter pub get` resolution failure
+
 ## 1.2.1
 
 > **🔔 推荐升级 / Upgrade recommended：** 本版本修复了 FPS 计算的根本性准确度问题（时间戳错误、漏判 GPU 卡顿），所有使用 FPS 监控功能的用户建议升级到最新版本。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 [![pub points](https://img.shields.io/pub/points/zero_inspector_kit.svg)](https://pub.dev/packages/zero_inspector_kit/score)
 [![CI](https://github.com/zero-labsco/zero_inspector_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/zero-labsco/zero_inspector_kit/actions/workflows/ci.yml)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://github.com/zero-labsco/zero_inspector_kit/blob/main/LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS-green.svg)]()
+[![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS-green.svg)](https://pub.dev/packages/zero_inspector_kit)
 [![Flutter](https://img.shields.io/badge/Flutter-✓-02569B?logo=flutter)](https://flutter.dev)
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 Upgrade recommended:** v1.2.1 fixes fundamental FPS accuracy issues (timestamps used `DateTime.now()` instead of real frame timestamps; frame duration only counted build phase, missing GPU rasterization jank). All users using the FPS monitor feature are advised to upgrade to `^1.2.1`.
+> **🔔 Upgrade recommended:** v1.2.2 fixes interceptor robustness issues (large-response OOM, overwritten third-party error reporting, concurrent same-URL request mis-association) and an unresolvable example dependency. All users are advised to upgrade to `^1.2.2`.
 
 🌐 **[Official Website](https://www.zerolabsco.com/)**
 
@@ -38,19 +38,19 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.2.1
+  zero_inspector_kit: ^1.2.2
 ```
 
 ### GitHub
 
-Alternatively, you can install from GitHub (replace `1.2.1` with the version you need):
+Alternatively, you can install from GitHub (replace `1.2.2` with the version you need):
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.2.1
+      ref: v1.2.2
 ```
 
 ## Usage

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,7 +6,7 @@
 [![pub points](https://img.shields.io/pub/points/zero_inspector_kit.svg)](https://pub.dev/packages/zero_inspector_kit/score)
 [![CI](https://github.com/zero-labsco/zero_inspector_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/zero-labsco/zero_inspector_kit/actions/workflows/ci.yml)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://github.com/zero-labsco/zero_inspector_kit/blob/main/LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS-green.svg)]()
+[![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS-green.svg)](https://pub.dev/packages/zero_inspector_kit)
 [![Flutter](https://img.shields.io/badge/Flutter-✓-02569B?logo=flutter)](https://flutter.dev)
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,7 @@
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 推荐升级：** v1.2.1 修复了 FPS 计算的根本性准确度问题（时间戳使用 `DateTime.now()` 而非帧真实时间戳；帧耗时只算 build 阶段，漏掉 GPU 光栅化卡顿）。建议所有使用 FPS 监控功能的用户升级到 `^1.2.1`。
+> **🔔 推荐升级：** v1.2.2 修复了拦截器的若干健壮性问题（大响应体 OOM、第三方错误上报被覆盖、并发同 URL 请求错乱）并修复了 example 依赖无法解析的问题。建议所有用户升级到 `^1.2.2`。
 
 🌐 **[官方网站](https://www.zerolabsco.com/)**
 
@@ -37,7 +37,7 @@
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.2.1
+  zero_inspector_kit: ^1.2.2
 ```
 
 ### GitHub

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     path: ../
 
 
-  dio: 5.11.0
+  dio: 5.4.0
   http: 1.6.0
   cupertino_icons: 1.0.9
   logger: 2.7.0

--- a/ios/zero_inspector_kit.podspec
+++ b/ios/zero_inspector_kit.podspec
@@ -4,10 +4,10 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'zero_inspector_kit'
-  s.version          = '1.2.1'
+  s.version          = '1.2.2'
   s.summary          = 'A Flutter plugin for in-app developer console.'
   s.description      = <<-DESC
-A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, and route tracking.
+A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.
                        DESC
   s.homepage         = 'https://github.com/zero-labsco/zero_inspector_kit'
   s.license          = { :file => '../LICENSE' }

--- a/lib/src/interceptors/dio_interceptor.dart
+++ b/lib/src/interceptors/dio_interceptor.dart
@@ -71,16 +71,11 @@ class InspectorDioInterceptor extends InspectorDioInterceptorBase {
 
   @override
   void onResponse(Map<String, dynamic> response) {
+    // 优先通过 request ID 匹配，避免并发同 URL 请求错乱
+    // Prefer matching by request ID to avoid wrong association for concurrent same-URL requests
+    final requestId = _extractRequestId(response['requestOptions']);
     final requestUrl = response['requestOptions']?['uri']?.toString() ?? '';
-    final request = InspectorService.instance.networkRequests.firstWhere(
-      (r) => r.url == requestUrl && r.responseTime == null,
-      orElse: () => NetworkRequest(
-        id: _generateId(),
-        method: response['requestOptions']?['method'] as String? ?? 'GET',
-        url: requestUrl,
-        requestTime: DateTime.now().millisecondsSinceEpoch,
-      ),
-    );
+    final request = _findRequestByIdOrUrl(requestId, requestUrl);
     InspectorService.instance.updateNetworkRequest(
       request.id,
       responseBody: response['data'],
@@ -90,21 +85,52 @@ class InspectorDioInterceptor extends InspectorDioInterceptorBase {
 
   @override
   void onError(Map<String, dynamic> error) {
+    // 优先通过 request ID 匹配，避免并发同 URL 请求错乱
+    // Prefer matching by request ID to avoid wrong association for concurrent same-URL requests
+    final requestId = _extractRequestId(error['requestOptions']);
     final requestUrl = error['requestOptions']?['uri']?.toString() ?? '';
-    final request = InspectorService.instance.networkRequests.firstWhere(
-      (r) => r.url == requestUrl && r.responseTime == null,
-      orElse: () => NetworkRequest(
-        id: _generateId(),
-        method: error['requestOptions']?['method'] as String? ?? 'GET',
-        url: requestUrl,
-        requestTime: DateTime.now().millisecondsSinceEpoch,
-      ),
-    );
+    final request = _findRequestByIdOrUrl(requestId, requestUrl);
     InspectorService.instance.updateNetworkRequest(
       request.id,
       responseBody: error['response']?['data'] ?? error['message'],
       statusCode: error['response']?['statusCode'] as int?,
     );
+  }
+
+  /// 从 requestOptions 中提取 request ID / Extract request ID from requestOptions
+  String? _extractRequestId(dynamic requestOptions) {
+    if (requestOptions is Map) {
+      final headers = requestOptions['headers'];
+      if (headers is Map) {
+        return headers[_requestIdHeader] as String?;
+      }
+    }
+    return null;
+  }
+
+  /// 通过 request ID 或 URL 查找匹配的请求 / Find matching request by ID or URL
+  ///
+  /// 优先按 ID 匹配（精确），回退按 URL + 未响应匹配（模糊，兼容旧行为）
+  /// Prefer matching by ID (exact), fall back to URL + no responseTime (fuzzy, backward compatible)
+  NetworkRequest _findRequestByIdOrUrl(String? requestId, String url) {
+    // 1. 精确匹配：通过 request ID / Exact match: by request ID
+    if (requestId != null) {
+      final requests = InspectorService.instance.networkRequests;
+      final byId = requests.where((r) => r.id == requestId);
+      if (byId.isNotEmpty) return byId.first;
+    }
+
+    // 2. 模糊匹配：通过 URL + 未响应（兼容旧逻辑）/ Fuzzy: URL + no responseTime
+    final request = InspectorService.instance.networkRequests.firstWhere(
+      (r) => r.url == url && r.responseTime == null,
+      orElse: () => NetworkRequest(
+        id: requestId ?? _generateId(),
+        method: 'GET',
+        url: url,
+        requestTime: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+    return request;
   }
 
   /// 生成唯一请求ID / Generate unique request ID

--- a/lib/src/interceptors/http_interceptor.dart
+++ b/lib/src/interceptors/http_interceptor.dart
@@ -502,6 +502,15 @@ class _InspectorResponseProxy implements HttpClientResponse {
   final List<int> _bodyBytes = [];
   bool _isCaptured = false;
 
+  /// 响应体最大捕获字节数 / Max response body capture size in bytes
+  ///
+  /// 超过此大小的响应体不再完整缓冲，避免大文件下载导致 OOM
+  /// Response bodies exceeding this size are not fully buffered to avoid OOM on large downloads
+  static const int _maxCaptureBytes = 512 * 1024; // 512 KB
+
+  /// 是否已超过捕获限制 / Whether capture limit has been exceeded
+  bool _captureExceeded = false;
+
   _InspectorResponseProxy(
     this._response,
     this._requestId, {
@@ -515,7 +524,13 @@ class _InspectorResponseProxy implements HttpClientResponse {
     _isCaptured = true;
     try {
       if (_requestId != null) {
-        final body = utf8.decode(_bodyBytes);
+        final String body;
+        if (_captureExceeded) {
+          body = '[Response body too large to capture '
+              '(${_response.contentLength} bytes)]';
+        } else {
+          body = utf8.decode(_bodyBytes);
+        }
         InspectorService.instance.updateNetworkRequest(
           _requestId,
           statusCode: _response.statusCode,
@@ -665,7 +680,17 @@ class _InspectorResponseProxy implements HttpClientResponse {
     return _response.transform(
       StreamTransformer<List<int>, List<int>>.fromHandlers(
         handleData: (chunk, sink) {
-          _bodyBytes.addAll(chunk);
+          if (!_captureExceeded &&
+              _bodyBytes.length + chunk.length <= _maxCaptureBytes) {
+            _bodyBytes.addAll(chunk);
+          } else if (!_captureExceeded) {
+            // 超过限制，截断到最大值并标记 / Exceeded limit, truncate to max and mark
+            final remaining = _maxCaptureBytes - _bodyBytes.length;
+            if (remaining > 0) {
+              _bodyBytes.addAll(chunk.sublist(0, remaining));
+            }
+            _captureExceeded = true;
+          }
           sink.add(chunk);
         },
         handleDone: (sink) {

--- a/lib/src/interceptors/http_interceptor.dart
+++ b/lib/src/interceptors/http_interceptor.dart
@@ -526,7 +526,8 @@ class _InspectorResponseProxy implements HttpClientResponse {
       if (_requestId != null) {
         final String body;
         if (_captureExceeded) {
-          body = '[Response body too large to capture '
+          body =
+              '[Response body too large to capture '
               '(${_response.contentLength} bytes)]';
         } else {
           body = utf8.decode(_bodyBytes);

--- a/lib/src/interceptors/log_interceptor.dart
+++ b/lib/src/interceptors/log_interceptor.dart
@@ -21,6 +21,9 @@ class InspectorLogInterceptor {
   /// 原始的 debugPrint 函数引用 / Original debugPrint function reference
   DebugPrintCallback? _originalDebugPrint;
 
+  /// 原始的 FlutterError.onError 回调 / Original FlutterError.onError callback
+  FlutterExceptionHandler? _originalFlutterOnError;
+
   /// 是否正在捕获日志（防止递归调用）/ Whether currently capturing logs (prevents recursive calls)
   bool _isCapturing = false;
 
@@ -43,6 +46,7 @@ class InspectorLogInterceptor {
   void stop() {
     _isStarted = false;
     _restoreDebugPrint();
+    _restoreFlutterOnError();
   }
 
   /// 覆盖 debugPrint 函数，实现日志捕获 / Override debugPrint function to capture logs
@@ -69,8 +73,13 @@ class InspectorLogInterceptor {
 
   /// 设置错误处理，捕获 Flutter 错误和异常 / Set up error handling to capture Flutter errors and exceptions
   void _setupErrorHandling() {
-    // 捕获 Flutter 框架级别的错误 / Capture Flutter framework-level errors
+    // 保存原始回调，避免覆盖 Crashlytics / Sentry 等第三方错误上报
+    // Save original callback to avoid overwriting Crashlytics / Sentry etc.
+    _originalFlutterOnError = FlutterError.onError;
     FlutterError.onError = (FlutterErrorDetails details) {
+      // 先调用原始回调（如 Crashlytics），确保错误上报不丢失
+      // Call original callback first (e.g. Crashlytics) to preserve error reporting
+      _originalFlutterOnError?.call(details);
       captureLog(details.exception.toString(), LogLevel.error);
       if (details.stack != null) {
         captureLog(details.stack.toString(), LogLevel.error);
@@ -82,6 +91,14 @@ class InspectorLogInterceptor {
       captureLog(error.toString(), LogLevel.error);
       captureLog(stackTrace.toString(), LogLevel.error);
     });
+  }
+
+  /// 恢复原始的 FlutterError.onError / Restore original FlutterError.onError
+  void _restoreFlutterOnError() {
+    if (_originalFlutterOnError != null) {
+      FlutterError.onError = _originalFlutterOnError!;
+      _originalFlutterOnError = null;
+    }
   }
 
   /// 捕获日志并添加到服务中 / Capture log and add to service

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zero_inspector_kit
 description: A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/zero-labsco/zero_inspector_kit
 repository: https://github.com/zero-labsco/zero_inspector_kit
 

--- a/test/log_interceptor_test.dart
+++ b/test/log_interceptor_test.dart
@@ -337,6 +337,7 @@ void main() {
         void mockHandler(FlutterErrorDetails details) {
           mockHandlerCalled = details;
         }
+
         FlutterError.onError = mockHandler;
 
         // 启动日志拦截器 / Start log interceptor
@@ -344,7 +345,10 @@ void main() {
 
         // 触发 FlutterError / Trigger FlutterError
         FlutterError.onError!(
-          FlutterErrorDetails(exception: Exception('test'), stack: StackTrace.current),
+          FlutterErrorDetails(
+            exception: Exception('test'),
+            stack: StackTrace.current,
+          ),
         );
 
         // 原始回调应被调用（Crashlytics 不丢失）/ Original handler should be called
@@ -371,18 +375,24 @@ void main() {
         void mockHandler(FlutterErrorDetails details) {
           callOrder.add('original');
         }
+
         FlutterError.onError = mockHandler;
 
         InspectorLogInterceptor.instance.start();
 
         FlutterError.onError!(
-          FlutterErrorDetails(exception: Exception('test'), stack: StackTrace.current),
+          FlutterErrorDetails(
+            exception: Exception('test'),
+            stack: StackTrace.current,
+          ),
         );
 
         // 原始回调应先于日志捕获被调用 / Original handler called before log capture
         expect(callOrder, contains('original'));
         expect(
-          InspectorService.instance.logEntries.any((e) => e.level == LogLevel.error),
+          InspectorService.instance.logEntries.any(
+            (e) => e.level == LogLevel.error,
+          ),
           isTrue,
         );
 

--- a/test/log_interceptor_test.dart
+++ b/test/log_interceptor_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zero_inspector_kit/src/interceptors/log_interceptor.dart';
 import 'package:zero_inspector_kit/src/models/log_entry.dart';
@@ -318,5 +319,76 @@ void main() {
       expect(logs[0].message, equals('warn via log()'));
       expect(logs[0].tag, equals('X'));
     });
+  });
+
+  /// =======================================================================
+  /// FlutterError.onError 保留与恢复测试 / FlutterError.onError preservation tests
+  /// =======================================================================
+  group('InspectorLogInterceptor FlutterError.onError preservation', () {
+    test(
+      'stop() 恢复原始 FlutterError.onError / stop() restores original FlutterError.onError',
+      () {
+        // 保存原始值 / Save original value
+        final originalOnError = FlutterError.onError;
+
+        // 设置一个模拟的第三方错误处理回调（如 Crashlytics）
+        // Set a mock third-party error handler (e.g. Crashlytics)
+        FlutterErrorDetails? mockHandlerCalled;
+        void mockHandler(FlutterErrorDetails details) {
+          mockHandlerCalled = details;
+        }
+        FlutterError.onError = mockHandler;
+
+        // 启动日志拦截器 / Start log interceptor
+        InspectorLogInterceptor.instance.start();
+
+        // 触发 FlutterError / Trigger FlutterError
+        FlutterError.onError!(
+          FlutterErrorDetails(exception: Exception('test'), stack: StackTrace.current),
+        );
+
+        // 原始回调应被调用（Crashlytics 不丢失）/ Original handler should be called
+        expect(mockHandlerCalled, isNotNull);
+
+        // 停止拦截器 / Stop interceptor
+        InspectorLogInterceptor.instance.stop();
+
+        // FlutterError.onError 应恢复为 mockHandler / Should restore to mockHandler
+        expect(FlutterError.onError, same(mockHandler));
+
+        // 重置 / Reset
+        FlutterError.onError = originalOnError;
+      },
+    );
+
+    test(
+      'start() 时原始 FlutterError.onError 被优先调用 / Original FlutterError.onError called first on start',
+      () {
+        final originalOnError = FlutterError.onError;
+
+        // 追踪调用顺序 / Track call order
+        final callOrder = <String>[];
+        void mockHandler(FlutterErrorDetails details) {
+          callOrder.add('original');
+        }
+        FlutterError.onError = mockHandler;
+
+        InspectorLogInterceptor.instance.start();
+
+        FlutterError.onError!(
+          FlutterErrorDetails(exception: Exception('test'), stack: StackTrace.current),
+        );
+
+        // 原始回调应先于日志捕获被调用 / Original handler called before log capture
+        expect(callOrder, contains('original'));
+        expect(
+          InspectorService.instance.logEntries.any((e) => e.level == LogLevel.error),
+          isTrue,
+        );
+
+        InspectorLogInterceptor.instance.stop();
+        FlutterError.onError = originalOnError;
+      },
+    );
   });
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -864,44 +864,43 @@ void main() {
         });
 
         // 应更新正确的请求 / Should update the correct request
-        final updated = InspectorService.instance.networkRequests
-            .firstWhere((r) => r.id == firstRequestId);
+        final updated = InspectorService.instance.networkRequests.firstWhere(
+          (r) => r.id == firstRequestId,
+        );
         expect(updated.responseBody, equals('second response'));
         expect(updated.statusCode, equals(200));
       },
     );
 
-    test(
-      'onError 通过 request ID 匹配 / onError matches by request ID',
-      () {
-        final interceptor = InspectorDioInterceptor();
+    test('onError 通过 request ID 匹配 / onError matches by request ID', () {
+      final interceptor = InspectorDioInterceptor();
 
-        interceptor.onRequest({
+      interceptor.onRequest({
+        'method': 'POST',
+        'url': 'https://api.example.com/login',
+        'headers': <String, dynamic>{},
+        'data': {'user': 'test'},
+      });
+
+      final requests = InspectorService.instance.networkRequests;
+      expect(requests.length, equals(1));
+      final requestId = requests.first.id;
+
+      interceptor.onError({
+        'message': 'Connection refused',
+        'response': {'statusCode': 503, 'data': 'Service Unavailable'},
+        'requestOptions': {
+          'uri': 'https://api.example.com/login',
           'method': 'POST',
-          'url': 'https://api.example.com/login',
-          'headers': <String, dynamic>{},
-          'data': {'user': 'test'},
-        });
+          'headers': {'x-inspector-request-id': requestId},
+        },
+      });
 
-        final requests = InspectorService.instance.networkRequests;
-        expect(requests.length, equals(1));
-        final requestId = requests.first.id;
-
-        interceptor.onError({
-          'message': 'Connection refused',
-          'response': {'statusCode': 503, 'data': 'Service Unavailable'},
-          'requestOptions': {
-            'uri': 'https://api.example.com/login',
-            'method': 'POST',
-            'headers': {'x-inspector-request-id': requestId},
-          },
-        });
-
-        final updated = InspectorService.instance.networkRequests
-            .firstWhere((r) => r.id == requestId);
-        expect(updated.statusCode, equals(503));
-        expect(updated.responseBody, equals('Service Unavailable'));
-      },
-    );
+      final updated = InspectorService.instance.networkRequests.firstWhere(
+        (r) => r.id == requestId,
+      );
+      expect(updated.statusCode, equals(503));
+      expect(updated.responseBody, equals('Service Unavailable'));
+    });
   });
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zero_inspector_kit/src/interceptors/dio_interceptor.dart';
 import 'package:zero_inspector_kit/src/models/database_info.dart';
 import 'package:zero_inspector_kit/src/models/interceptor_rule.dart';
 import 'package:zero_inspector_kit/src/models/leak_record.dart';
@@ -6,6 +7,7 @@ import 'package:zero_inspector_kit/src/models/log_entry.dart';
 import 'package:zero_inspector_kit/src/models/memory_snapshot.dart';
 import 'package:zero_inspector_kit/src/models/network_request.dart';
 import 'package:zero_inspector_kit/src/models/route_entry.dart';
+import 'package:zero_inspector_kit/src/services/inspector_service.dart';
 
 /// 模型单元测试 / Model unit tests
 ///
@@ -807,5 +809,99 @@ void main() {
       expect(r.leakedAt, equals(now));
       expect(r.status, equals(LeakStatus.verifying));
     });
+  });
+
+  /// =======================================================================
+  /// InspectorDioInterceptor — 请求 ID 匹配测试 / Request ID matching tests
+  /// =======================================================================
+  group('InspectorDioInterceptor request ID matching', () {
+    setUp(() {
+      InspectorService.instance.clearNetworkRequests();
+    });
+
+    tearDown(() {
+      InspectorService.instance.clearNetworkRequests();
+    });
+
+    test(
+      'onResponse 通过 request ID 精确匹配而非 URL / onResponse matches by request ID, not URL',
+      () {
+        final interceptor = InspectorDioInterceptor();
+
+        // 模拟两个并发请求到同一 URL / Simulate two concurrent requests to same URL
+        interceptor.onRequest({
+          'method': 'GET',
+          'url': 'https://api.example.com/user',
+          'headers': <String, dynamic>{},
+          'data': null,
+        });
+        interceptor.onRequest({
+          'method': 'GET',
+          'url': 'https://api.example.com/user',
+          'headers': <String, dynamic>{},
+          'data': null,
+        });
+
+        final requests = InspectorService.instance.networkRequests;
+        expect(requests.length, equals(2));
+
+        // 获取第一个请求的 ID / Get first request's ID
+        final firstRequestId = requests
+            .where((r) => r.responseTime == null)
+            .last
+            .id;
+
+        // 模拟第二个请求先返回（携带同一 URL 但带上 request ID header）
+        // Simulate second request responding first (same URL but with request ID header)
+        interceptor.onResponse({
+          'statusCode': 200,
+          'data': 'second response',
+          'requestOptions': {
+            'uri': 'https://api.example.com/user',
+            'method': 'GET',
+            'headers': {'x-inspector-request-id': firstRequestId},
+          },
+        });
+
+        // 应更新正确的请求 / Should update the correct request
+        final updated = InspectorService.instance.networkRequests
+            .firstWhere((r) => r.id == firstRequestId);
+        expect(updated.responseBody, equals('second response'));
+        expect(updated.statusCode, equals(200));
+      },
+    );
+
+    test(
+      'onError 通过 request ID 匹配 / onError matches by request ID',
+      () {
+        final interceptor = InspectorDioInterceptor();
+
+        interceptor.onRequest({
+          'method': 'POST',
+          'url': 'https://api.example.com/login',
+          'headers': <String, dynamic>{},
+          'data': {'user': 'test'},
+        });
+
+        final requests = InspectorService.instance.networkRequests;
+        expect(requests.length, equals(1));
+        final requestId = requests.first.id;
+
+        interceptor.onError({
+          'message': 'Connection refused',
+          'response': {'statusCode': 503, 'data': 'Service Unavailable'},
+          'requestOptions': {
+            'uri': 'https://api.example.com/login',
+            'method': 'POST',
+            'headers': {'x-inspector-request-id': requestId},
+          },
+        });
+
+        final updated = InspectorService.instance.networkRequests
+            .firstWhere((r) => r.id == requestId);
+        expect(updated.statusCode, equals(503));
+        expect(updated.responseBody, equals('Service Unavailable'));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary / 摘要

- **HTTP 拦截器 OOM 防护**：捕获的响应体上限设为 512KB，超过则以占位文案替代，避免下载大文件（视频、大 JSON）时内存溢出。
  HTTP interceptor: cap captured response body at 512KB; larger bodies are replaced with a placeholder to avoid OOM on large downloads.
- **日志拦截器保留第三方错误上报**：`start()` 时保存原始 `FlutterError.onError` 并优先调用，`stop()` 时恢复，不再覆盖 Crashlytics / Sentry 等错误上报。
  Log interceptor: preserve and restore the original `FlutterError.onError` so third-party reporters (Crashlytics/Sentry) are no longer overwritten.
- **Dio 拦截器按请求 ID 精确匹配**：`onResponse` / `onError` 优先通过 `x-inspector-request-id` 匹配，回退到 URL，避免并发同 URL 请求错乱配对。
  Dio interceptor: match responses/errors by `x-inspector-request-id` first, falling back to URL, to avoid mis-associating concurrent same-URL requests.
- **Example 依赖修复**：`example/pubspec.yaml` 的 `dio` 由不存在的 `5.11.0` 固定为 `5.4.0`，修复 `flutter pub get` 解析失败。
  Example dependency fix: pin `dio` from the non-existent `5.11.0` to `5.4.0`, fixing `flutter pub get` resolution failure.
- **版本发布 / Release v1.2.2**：更新 `pubspec.yaml` 与 `ios/zero_inspector_kit.podspec` 版本号，补全 podspec description，并同步 CHANGELOG / README / README_zh。
  Bump version to 1.2.2 in `pubspec.yaml` and the iOS podspec; complete the podspec description; update CHANGELOG / README / README_zh.

## Why / 目的

这些拦截器问题是在评审一个自动生成的 agent 分支时发现的真实健壮性缺陷：大响应体 OOM、第三方错误上报被静默覆盖、以及并发同 URL 请求的错配。本 PR 在保留原有行为的基础上修复了这三类问题，并顺带修正了 example 无法解析的依赖版本。

These interceptor issues were real robustness defects (found while reviewing an auto-generated agent branch): OOM on large bodies, silently overwritten third-party error reporters, and mis-association of concurrent same-URL requests. This PR fixes all three while preserving existing behavior, and also fixes an unresolvable example dependency.

## Test plan / 验证

- [x] `dart analyze lib test` — No issues found.
- [x] `flutter test` — 全部通过（含新增的 FlutterError 保留/恢复与 Dio 请求 ID 匹配测试）。
- [x] 版本号 `pubspec.yaml` 与 `ios/zero_inspector_kit.podspec` 均改为 `1.2.2`。
- [ ] 发布前执行 `git tag v1.2.2 && git push origin v1.2.2` 并触发 `pub-publish.yml`。

🤖 Generated with [ZeroBuddy](https://www.zerolabsco.com)
