### PR TITLE
docs: document release-vX.Y.Z archive branch convention and tag-driven publish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,9 @@ This file defines the architecture, coding conventions, and required workflows f
    - `flutter test` — all unit tests green.
    - `flutter pub publish --dry-run` — confirm the package scores well on `pana` and no files are unintentionally excluded.
 4. Commit on a branch, open PR, merge to `main` after the 3 required checks pass.
-5. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-6. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
+5. Tag (drives publishing): `git tag vX.Y.Z <commit> && git push origin vX.Y.Z`. The `vX.Y.Z` tag — NOT a branch — triggers `pub-publish.yml`. Never name a branch `vX.Y.Z`; it collides with the tag refspec and breaks `git push`.
+6. Archive branch (optional, for release snapshots): create `release-vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release-vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots.
+7. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
    - Note: `k-paxian` internally uses older actions that emit Node 20 deprecation warnings. This is accepted (B1 decision); functionality is unaffected.
 
 ### Documentation site (GitHub Pages)
@@ -79,4 +80,4 @@ This file defines the architecture, coding conventions, and required workflows f
 - [ ] Use a typed branch (`feat/...`) and a Conventional Commits PR title.
 - [ ] Ensure the 3 required status checks pass before requesting review/merge.
 - [ ] For user-facing changes, update `README.md` and the `docs/` site.
-- [ ] For releases, bump `version`, update changelog, tag `vX.Y.Z`, and let `pub-publish.yml` publish.
+- [ ] For releases, bump `version`, update changelog, tag `vX.Y.Z` (triggers publish), and optionally push a `release-vX.Y.Z` archive branch via explicit refspec.


### PR DESCRIPTION
### Summary / 摘要

Document the release branching and tag conventions in `AGENTS.md` so AI agents and contributors follow a single, conflict-free rule.

在 `AGENTS.md` 中补充发布分支与 tag 的约定，确保 AI 协作工具与贡献者遵循统一、无冲突的规则。

### Changes / 变更

- Clarify that the `vX.Y.Z` **tag** (not a branch) triggers `pub-publish.yml`; warn against naming a branch `vX.Y.Z` because it collides with the tag refspec and breaks `git push`.
  明确 `vX.Y.Z` **tag**（而非分支）用于触发 `pub-publish.yml`；并警告不要把分支命名为 `vX.Y.Z`，否则会与 tag 的 refspec 冲突、破坏 `git push`。
- Add the `release-vX.Y.Z` archive-branch convention, created via explicit refspec (`git push origin <commit>:refs/heads/release-vX.Y.Z`) to avoid the tag/branch collision. These branches are inert (no CI triggers) and serve only as frozen release snapshots.
  新增 `release-vX.Y.Z` 归档分支约定，通过显式 refspec 创建以规避冲突。该分支不触发 CI，仅作发布快照留底。
- Update the release checklist accordingly.
  同步更新发布清单。

### Context / 背景

The remote `v*` archive branches were renamed to `release-v*` to prevent tag/branch refspec ambiguity. This PR records that decision in `AGENTS.md`.

远程的 `v*` 归档分支已重命名为 `release-*`，以避免 tag 与分支的 refspec 歧义。本 PR 将该决策写入 `AGENTS.md`。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] `AGENTS.md` updated / 已更新
- [ ] CI checks pass after merge / 合入后 CI 通过
