### PR TITLE
docs: sync CONTRIBUTING release process with branch/tag convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,16 +206,21 @@ Releases are managed by maintainers via git tags:
 1. Ensure `pubspec.yaml` `version` is updated.
 2. Ensure `CHANGELOG.md` is updated with the new version section.
 3. Commit and push to `main`.
-4. Create and push a tag `v<version>` (e.g., `v1.2.2`):
+4. Create and push a tag `v<version>` (e.g., `v1.2.2`). **Do not name a branch `v<version>`** — a same-named branch/tag pair makes `git push origin v<version>` ambiguous. Use `refs/tags/` to push the tag explicitly:
 
    ```bash
    git tag v1.2.2
-   git push origin v1.2.2
+   git push origin refs/tags/v1.2.2
    ```
 
 5. The `pub-publish.yml` workflow will automatically publish to pub.dev and create a GitHub Release.
+6. (Optional) Archive the release as a branch named `release-v<version>` (e.g., `release-v1.2.2`). This branch does **not** trigger CI and exists only for archival. Create it via an explicit refspec:
 
-> 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`);5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release。
+   ```bash
+   git push origin main:refs/heads/release-v1.2.2
+   ```
+
+> 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release-v<version>` 命名归档分支(如 `release-v1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
 
 ---
 


### PR DESCRIPTION
## Summary

同步 `CONTRIBUTING.md` 的 Release Process 一节与已合入 `main` 的发布约定（AGENTS.md 更新），保持一致：

- 发布标签推送改用显式 `refs/tags/v<version>`，并警告**不要将分支命名为 `v<version>`**（同名分支/tag 会导致 `git push origin v<version>` 歧义）。
- 新增可选的 `release-v<version>` 归档分支说明：不触发 CI、仅作归档，需经显式 refspec (`main:refs/heads/release-v<version>`) 创建。

## Test plan

- [x] 文档改动，无代码逻辑影响
- [x] 已 `git push origin docs/release-branch-convention`

🤖 Generated with [ZeroBuddy](https://www.zerolabsco.com)
