### PR TITLE
ci: skip CI for CONTRIBUTING.md and non-build workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,16 @@ on:
       # so docs-only PRs still run CI and satisfy branch protection's required checks.
       - 'README*.md'         # README files
       - 'CHANGELOG.md'       # Changelog
+      - 'CONTRIBUTING.md'    # Contributing guide (doesn't affect the package)
       - 'TODO.md'            # Todo file
       - 'wiki/**'            # Wiki documentation directory
       - 'docs/**'            # GitHub Pages content
       # 精细化忽略 GitHub 配置，但保留 workflows/ 目录的 CI 触发（Dependabot 改 action 版本需要跑 CI）
       # Finer-grained GitHub ignores — workflows MUST trigger CI (Dependabot action updates need CI)
       - '.github/ISSUE_TEMPLATE/**'     # Issue/PR templates
-      - '.github/workflows/stale.yml'   # Stale bot doesn't affect builds/publish
+      - '.github/workflows/stale.yml'          # Stale bot doesn't affect builds/publish
+      - '.github/workflows/link-check.yml'     # Link checker doesn't affect builds/publish
+      - '.github/workflows/dependabot-pr-bilingual.yml'  # PR body text injection doesn't affect builds/publish
       - '**.png'             # PNG images
       - '**.jpg'             # JPG images
       - '**.jpeg'            # JPEG images
@@ -42,6 +45,7 @@ on:
       # so docs-only PRs still run CI and satisfy branch protection's required checks.
       - 'README*.md'         # README files
       - 'CHANGELOG.md'       # Changelog
+      - 'CONTRIBUTING.md'    # Contributing guide (doesn't affect the package)
       - 'TODO.md'            # Todo file
       - 'wiki/**'            # Wiki documentation directory
       - 'docs/**'            # GitHub Pages content
@@ -49,6 +53,8 @@ on:
       # Finer-grained GitHub ignores — workflows MUST trigger CI
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/stale.yml'
+      - '.github/workflows/link-check.yml'
+      - '.github/workflows/dependabot-pr-bilingual.yml'
       - '**.png'
       - '**.jpg'
       - '**.jpeg'


### PR DESCRIPTION
## Summary

扩展 `ci.yml` 的 `paths-ignore`（push 与 pull_request 两处），让仅改以下文件时完全跳过 CI：

- `CONTRIBUTING.md`（贡献指南，不影响包）
- `.github/workflows/link-check.yml`（纯链接检查）
- `.github/workflows/dependabot-pr-bilingual.yml`（仅向 PR 体注入文案）

`AGENTS.md` 与 `.codebuddy/**` 仍故意保留触发，确保 docs-only PR 仍能满足分支保护的 3 项必需检查；`ci.yml` 与 `stale.yml` 的处理维持原样。

## Test plan

- [x] 纯 YAML 配置改动，无代码逻辑影响
- [x] 已 push 到 `ci/paths-ignore-docs`

🤖 Generated with [ZeroBuddy](https://www.zerolabsco.com)
