### PR TITLE
docs: rename archive branch convention to release/vX.Y.Z

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ This file defines the architecture, coding conventions, and required workflows f
    - `flutter pub publish --dry-run` — confirm the package scores well on `pana` and no files are unintentionally excluded.
 4. Commit on a branch, open PR, merge to `main` after the 3 required checks pass.
 5. Tag (drives publishing): `git tag vX.Y.Z <commit> && git push origin vX.Y.Z`. The `vX.Y.Z` tag — NOT a branch — triggers `pub-publish.yml`. Never name a branch `vX.Y.Z`; it collides with the tag refspec and breaks `git push`.
-6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots. Note: early versions `v1.1.0` and `v1.1.1` cannot be pushed as archive branches (their commits are rejected by the remote); those two versions are kept as tags only.
+6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots.
 7. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
    - Note: `k-paxian` internally uses older actions that emit Node 20 deprecation warnings. This is accepted (B1 decision); functionality is unaffected.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ This file defines the architecture, coding conventions, and required workflows f
    - `flutter pub publish --dry-run` — confirm the package scores well on `pana` and no files are unintentionally excluded.
 4. Commit on a branch, open PR, merge to `main` after the 3 required checks pass.
 5. Tag (drives publishing): `git tag vX.Y.Z <commit> && git push origin vX.Y.Z`. The `vX.Y.Z` tag — NOT a branch — triggers `pub-publish.yml`. Never name a branch `vX.Y.Z`; it collides with the tag refspec and breaks `git push`.
-6. Archive branch (optional, for release snapshots): create `release-vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release-vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots.
+6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots.
 7. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
    - Note: `k-paxian` internally uses older actions that emit Node 20 deprecation warnings. This is accepted (B1 decision); functionality is unaffected.
 
@@ -80,4 +80,4 @@ This file defines the architecture, coding conventions, and required workflows f
 - [ ] Use a typed branch (`feat/...`) and a Conventional Commits PR title.
 - [ ] Ensure the 3 required status checks pass before requesting review/merge.
 - [ ] For user-facing changes, update `README.md` and the `docs/` site.
-- [ ] For releases, bump `version`, update changelog, tag `vX.Y.Z` (triggers publish), and optionally push a `release-vX.Y.Z` archive branch via explicit refspec.
+- [ ] For releases, bump `version`, update changelog, tag `vX.Y.Z` (triggers publish), and optionally push a `release/vX.Y.Z` archive branch via explicit refspec.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ This file defines the architecture, coding conventions, and required workflows f
    - `flutter pub publish --dry-run` — confirm the package scores well on `pana` and no files are unintentionally excluded.
 4. Commit on a branch, open PR, merge to `main` after the 3 required checks pass.
 5. Tag (drives publishing): `git tag vX.Y.Z <commit> && git push origin vX.Y.Z`. The `vX.Y.Z` tag — NOT a branch — triggers `pub-publish.yml`. Never name a branch `vX.Y.Z`; it collides with the tag refspec and breaks `git push`.
-6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots.
+6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots. Note: early versions `v1.1.0` and `v1.1.1` cannot be pushed as archive branches (their commits are rejected by the remote); those two versions are kept as tags only.
 7. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
    - Note: `k-paxian` internally uses older actions that emit Node 20 deprecation warnings. This is accepted (B1 decision); functionality is unaffected.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,13 +214,13 @@ Releases are managed by maintainers via git tags:
    ```
 
 5. The `pub-publish.yml` workflow will automatically publish to pub.dev and create a GitHub Release.
-6. (Optional) Archive the release as a branch named `release-v<version>` (e.g., `release-v1.2.2`). This branch does **not** trigger CI and exists only for archival. Create it via an explicit refspec:
+6. (Optional) Archive the release as a branch named `release/<version>` (e.g., `release/1.2.2`). This branch does **not** trigger CI and exists only for archival. Create it via an explicit refspec:
 
    ```bash
-   git push origin main:refs/heads/release-v1.2.2
+   git push origin main:refs/heads/release/1.2.2
    ```
 
-> 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release-v<version>` 命名归档分支(如 `release-v1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
+> 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release/<version>` 命名归档分支(如 `release/1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,8 +220,6 @@ Releases are managed by maintainers via git tags:
    git push origin main:refs/heads/release/1.2.2
    ```
 
-   > Note: early versions `v1.1.0` and `v1.1.1` cannot be pushed as archive branches (their commits are rejected by the remote); those two versions are kept as tags only.
-
 > 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release/<version>` 命名归档分支(如 `release/1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,8 @@ Releases are managed by maintainers via git tags:
    git push origin main:refs/heads/release/1.2.2
    ```
 
+   > Note: early versions `v1.1.0` and `v1.1.1` cannot be pushed as archive branches (their commits are rejected by the remote); those two versions are kept as tags only.
+
 > 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release/<version>` 命名归档分支(如 `release/1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,13 +214,13 @@ Releases are managed by maintainers via git tags:
    ```
 
 5. The `pub-publish.yml` workflow will automatically publish to pub.dev and create a GitHub Release.
-6. (Optional) Archive the release as a branch named `release/<version>` (e.g., `release/1.2.2`). This branch does **not** trigger CI and exists only for archival. Create it via an explicit refspec:
+6. (Optional) Archive the release as a branch named `release/v<version>` (e.g., `release/v1.2.2`). This branch does **not** trigger CI and exists only for archival. Create it via an explicit refspec:
 
    ```bash
-   git push origin main:refs/heads/release/1.2.2
+   git push origin <commit>:refs/heads/release/v1.2.2
    ```
 
-> 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release/<version>` 命名归档分支(如 `release/1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
+> 发布由维护者通过 git tag 管理:1) 更新 `pubspec.yaml` 的 `version`;2) 更新 `CHANGELOG.md` 对应版本节;3) 提交并 push 到 `main`;4) 创建并 push `v<version>` tag(如 `v1.2.2`)——**不要把分支命名为 `v<version>`**,同名分支/tag 会让 push 产生歧义,请用 `refs/tags/` 显式推送;5) `pub-publish.yml` 工作流会自动发布到 pub.dev 并创建 GitHub Release;6)(可选)以 `release/v<version>` 命名归档分支(如 `release/v1.2.2`),该分支不触发 CI、仅作归档,需经显式 refspec 创建。
 
 ---
 


### PR DESCRIPTION
## Summary

将发布归档分支命名约定从 `release-vX.Y.Z` 改为 `release/vX.Y.Z`（使用 `release/` 命名空间）。

- 已在远程将全部 10 个历史归档分支重命名为 `release/vX.Y.Z`。
- 同步更新 `AGENTS.md` 与 `CONTRIBUTING.md` 中的相关说明与示例命令。
- 旧 `release-v*` 分支已全部删除。

## Test plan

- [x] 纯文档改动，无代码逻辑影响
- [x] 已推送至 `docs/release-branch-namespace`，远程 10 个 `release/` 分支已就绪

🤖 Generated with [Zeroddy](https://www.zerolabsco.com)
