### PR TITLE
fix: quote sqlite table names with double quotes instead of raw interpolation

### DIFF
--- a/lib/src/services/sqlite_provider.dart
+++ b/lib/src/services/sqlite_provider.dart
@@ -82,7 +82,7 @@ class SqliteDatabaseProvider implements DatabaseProvider {
   Future<List<ColumnInfo>> _getColumns(Database db, String tableName) async {
     final columns = <ColumnInfo>[];
     try {
-      final result = await db.rawQuery('PRAGMA table_info($tableName)');
+      final result = await db.rawQuery('PRAGMA table_info("$tableName")');
 
       for (final row in result) {
         columns.add(
@@ -97,7 +97,7 @@ class SqliteDatabaseProvider implements DatabaseProvider {
   /// 获取表的行数 / Get row count of table
   Future<int> _getRowCount(Database db, String tableName) async {
     try {
-      final result = await db.rawQuery('SELECT COUNT(*) FROM $tableName');
+      final result = await db.rawQuery('SELECT COUNT(*) FROM "$tableName"');
       return result.first.values.first as int;
     } catch (_) {
       return 0;
@@ -114,7 +114,7 @@ class SqliteDatabaseProvider implements DatabaseProvider {
       final db = await openDatabase(dbPath, readOnly: true, version: 1);
 
       final columns = await _getColumns(db, tableName);
-      final rows = await db.rawQuery('SELECT * FROM $tableName LIMIT $limit');
+      final rows = await db.rawQuery('SELECT * FROM "$tableName" LIMIT $limit');
 
       await db.close();
 


### PR DESCRIPTION
## 改动 / Changes

将 `lib/src/services/sqlite_provider.dart` 中表名拼接从裸字符串插值改为 SQLite 双引号标识符引用（`"$tableName"`），符合 SQLite 标识符引用规范。

- `PRAGMA table_info($tableName)` → `PRAGMA table_info("$tableName")`
- `SELECT COUNT(*) FROM $tableName` → `SELECT COUNT(*) FROM "$tableName"`
- `SELECT * FROM $tableName LIMIT $limit` → `SELECT * FROM "$tableName" LIMIT $limit`

## 动机 / Rationale

表名来自 `sqlite_master` 系统表，属内部可信来源，无注入风险。此改动仅为规范写法，不引入额外校验逻辑或测试。

## 影响 / Impact

- 纯内部实现规范化，公共 API 无变化，用户无感知。
- 不 bump 版本、不单独发布，随下次功能性更新一并发版。

## 验证 / Verification

- `flutter analyze` 无报错
- `flutter test` 全部通过（152 passed）
