### PR TITLE
refactor: surface database errors instead of silent empty state

### DIFF
--- a/lib/src/models/database_info.dart
+++ b/lib/src/models/database_info.dart
@@ -90,14 +90,14 @@ class QueryResult {
 
   /// 成功（可能为空）的结果 / A successful (possibly empty) result.
   const QueryResult.empty()
-      : rows = const [],
-        columns = const [],
-        totalRows = 0,
-        error = null;
+    : rows = const [],
+      columns = const [],
+      totalRows = 0,
+      error = null;
 
   /// 携带错误信息的失败结果 / A failed result carrying the error message.
   const QueryResult.failure(this.error)
-      : rows = const [],
-        columns = const [],
-        totalRows = 0;
+    : rows = const [],
+      columns = const [],
+      totalRows = 0;
 }

--- a/lib/src/models/database_info.dart
+++ b/lib/src/models/database_info.dart
@@ -9,7 +9,17 @@ class DatabaseInfo {
   /// 数据库表列表 / Database table list
   final List<TableInfo> tables;
 
-  DatabaseInfo({required this.name, required this.path, required this.tables});
+  /// 扫描该数据库时发生的错误（如无法打开）。非空时说明表列表可能不完整。
+  /// Error encountered while scanning this database (e.g. cannot open it).
+  /// Non-null means the table list may be incomplete.
+  final String? error;
+
+  DatabaseInfo({
+    required this.name,
+    required this.path,
+    required this.tables,
+    this.error,
+  });
 }
 
 /// 数据表信息模型 / Table info model
@@ -27,7 +37,13 @@ class TableInfo {
     required this.name,
     required this.rowCount,
     required this.columns,
+    this.error,
   });
+
+  /// 扫描该表时发生的错误（如无法读取 schema）。非空时说明列信息可能不完整。
+  /// Error encountered while scanning this table (e.g. cannot read schema).
+  /// Non-null means the column info may be incomplete.
+  final String? error;
 }
 
 /// 列信息模型 / Column info model
@@ -53,9 +69,35 @@ class QueryResult {
   /// Total filtered row count (for pagination). Falls back to [rows].length when absent.
   final int? totalRows;
 
-  QueryResult({required this.rows, required this.columns, this.totalRows});
+  /// 查询失败时非空。此时 [rows] 为空，UI 应渲染错误态而非（误导性的）空列表。
+  /// Non-null when the query failed. When set, [rows] is empty and the UI
+  /// should render an error state instead of a (misleading) empty list.
+  final String? error;
+
+  QueryResult({
+    required this.rows,
+    required this.columns,
+    this.totalRows,
+    this.error,
+  });
 
   /// 用于分页的总行数；未显式提供时按当前页行数近似。
   /// Total rows for pagination; approximates with current page length if not provided.
   int get total => totalRows ?? rows.length;
+
+  /// 查询是否失败 / Whether the query failed.
+  bool get hasError => error != null && error!.isNotEmpty;
+
+  /// 成功（可能为空）的结果 / A successful (possibly empty) result.
+  const QueryResult.empty()
+      : rows = const [],
+        columns = const [],
+        totalRows = 0,
+        error = null;
+
+  /// 携带错误信息的失败结果 / A failed result carrying the error message.
+  const QueryResult.failure(this.error)
+      : rows = const [],
+        columns = const [],
+        totalRows = 0;
 }

--- a/lib/src/services/sqlite_provider.dart
+++ b/lib/src/services/sqlite_provider.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
 import '../models/database_info.dart';
+import '../utils/inspector_internal_log.dart';
 import 'database_provider.dart';
 
 /// SQLite数据库提供者实现 / SQLite database provider implementation
@@ -41,6 +42,7 @@ class SqliteDatabaseProvider implements DatabaseProvider {
             if (databases.any((d) => d.path == file.path)) continue;
 
             Database? db;
+            String? scanError;
             try {
               db = await _openConnection(file.path);
               final tables = await _getTables(db);
@@ -51,16 +53,37 @@ class SqliteDatabaseProvider implements DatabaseProvider {
                   tables: tables,
                 ),
               );
-            } catch (_) {
-              // 单个文件打开失败不应阻断整个扫描 / A single bad file must not abort the scan.
+            } on DatabaseException catch (e, st) {
+              // 单个文件打开失败不应阻断整个扫描，但要把错误暴露出来。
+              // A single bad file must not abort the scan, but surface the error.
+              scanError = '无法打开数据库 ${file.path}: $e';
+              InspectorInternalLog.error('sqlite', scanError, error: e, stackTrace: st);
+            } catch (e, st) {
+              scanError = '扫描数据库 ${file.path} 失败: $e';
+              InspectorInternalLog.error('sqlite', scanError, error: e, stackTrace: st);
             } finally {
               // 扫描阶段不持有连接，归还缓存 / Don't keep connections during scan.
               _releaseConnection(file.path);
             }
+
+            // 打开/扫描失败也记录一条带错误信息的 DatabaseInfo，供 UI 提示。
+            // Record a DatabaseInfo carrying the error so the UI can warn.
+            if (scanError != null && !databases.any((d) => d.path == file.path)) {
+              databases.add(
+                DatabaseInfo(
+                  name: file.path.split(Platform.pathSeparator).last,
+                  path: file.path,
+                  tables: const [],
+                  error: scanError,
+                ),
+              );
+            }
           }
         }
       }
-    } catch (_) {}
+    } catch (e, st) {
+      InspectorInternalLog.error('sqlite', '扫描数据库目录失败: $e', error: e, stackTrace: st);
+    }
 
     return databases;
   }
@@ -77,14 +100,32 @@ class SqliteDatabaseProvider implements DatabaseProvider {
         final tableName = row['name'] as String;
         if (tableName.startsWith('sqlite_')) continue;
 
-        final columns = await _getColumns(db, tableName);
-        final rowCount = await _getRowCount(db, tableName);
+        List<ColumnInfo> columns = const [];
+        int rowCount = 0;
+        String? tableError;
+        try {
+          columns = await _getColumns(db, tableName);
+          rowCount = await _getRowCount(db, tableName);
+        } catch (e, st) {
+          tableError = '读取表 $tableName 的 schema 失败: $e';
+          InspectorInternalLog.warning('sqlite', tableError, error: e, stackTrace: st);
+        }
 
         tables.add(
-          TableInfo(name: tableName, rowCount: rowCount, columns: columns),
+          TableInfo(
+            name: tableName,
+            rowCount: rowCount,
+            columns: columns,
+            error: tableError,
+          ),
         );
       }
-    } catch (_) {}
+    } catch (e, st) {
+      // 读取 sqlite_master 失败：整库 schema 不可用，报错交由调用方记录。
+      // Reading sqlite_master failed: schema unavailable; caller logs it.
+      InspectorInternalLog.error('sqlite', '读取表列表失败: $e', error: e, stackTrace: st);
+      rethrow;
+    }
 
     return tables;
   }
@@ -102,7 +143,15 @@ class SqliteDatabaseProvider implements DatabaseProvider {
           ColumnInfo(name: row['name'] as String, type: row['type'] as String),
         );
       }
-    } catch (_) {}
+    } catch (e, st) {
+      InspectorInternalLog.warning(
+        'sqlite',
+        '读取表 $tableName 的列信息失败: $e',
+        error: e,
+        stackTrace: st,
+      );
+      rethrow;
+    }
 
     return columns;
   }
@@ -114,7 +163,13 @@ class SqliteDatabaseProvider implements DatabaseProvider {
         'SELECT COUNT(*) FROM ${_quoteIdent(tableName)}',
       );
       return result.first.values.first as int;
-    } catch (_) {
+    } catch (e, st) {
+      InspectorInternalLog.warning(
+        'sqlite',
+        '读取表 $tableName 的行数失败: $e',
+        error: e,
+        stackTrace: st,
+      );
       return 0;
     }
   }
@@ -164,10 +219,16 @@ class SqliteDatabaseProvider implements DatabaseProvider {
         columns: columnNames,
         totalRows: totalRows,
       );
-    } catch (_) {
-      // 查询失败时返回空结果；错误态由后续批次的 InspectorResult 暴露给 UI。
-      // On failure return empty; error surfacing via InspectorResult comes in a later batch.
-      return QueryResult(rows: [], columns: []);
+    } on DatabaseException catch (e, st) {
+      // 查询失败：把错误暴露给 UI，而不是伪装成空列表。
+      // Query failed: surface the error to the UI instead of faking an empty list.
+      final message = '查询表 $tableName 失败: $e';
+      InspectorInternalLog.error('sqlite', message, error: e, stackTrace: st);
+      return QueryResult.failure(message);
+    } catch (e, st) {
+      final message = '查询表 $tableName 时发生未知错误: $e';
+      InspectorInternalLog.error('sqlite', message, error: e, stackTrace: st);
+      return QueryResult.failure(message);
     } finally {
       // query 不持有连接，立即归还缓存 / query does not keep the connection.
       _releaseConnection(dbPath);
@@ -210,7 +271,9 @@ class SqliteDatabaseProvider implements DatabaseProvider {
     for (final db in _connections.values) {
       try {
         await db.close();
-      } catch (_) {}
+      } catch (e, st) {
+        InspectorInternalLog.warning('sqlite', '关闭数据库连接失败: $e', error: e, stackTrace: st);
+      }
     }
     _connections.clear();
     _accessOrder.clear();

--- a/lib/src/services/sqlite_provider.dart
+++ b/lib/src/services/sqlite_provider.dart
@@ -57,10 +57,20 @@ class SqliteDatabaseProvider implements DatabaseProvider {
               // 单个文件打开失败不应阻断整个扫描，但要把错误暴露出来。
               // A single bad file must not abort the scan, but surface the error.
               scanError = '无法打开数据库 ${file.path}: $e';
-              InspectorInternalLog.error('sqlite', scanError, error: e, stackTrace: st);
+              InspectorInternalLog.error(
+                'sqlite',
+                scanError,
+                error: e,
+                stackTrace: st,
+              );
             } catch (e, st) {
               scanError = '扫描数据库 ${file.path} 失败: $e';
-              InspectorInternalLog.error('sqlite', scanError, error: e, stackTrace: st);
+              InspectorInternalLog.error(
+                'sqlite',
+                scanError,
+                error: e,
+                stackTrace: st,
+              );
             } finally {
               // 扫描阶段不持有连接，归还缓存 / Don't keep connections during scan.
               _releaseConnection(file.path);
@@ -68,7 +78,8 @@ class SqliteDatabaseProvider implements DatabaseProvider {
 
             // 打开/扫描失败也记录一条带错误信息的 DatabaseInfo，供 UI 提示。
             // Record a DatabaseInfo carrying the error so the UI can warn.
-            if (scanError != null && !databases.any((d) => d.path == file.path)) {
+            if (scanError != null &&
+                !databases.any((d) => d.path == file.path)) {
               databases.add(
                 DatabaseInfo(
                   name: file.path.split(Platform.pathSeparator).last,
@@ -82,7 +93,12 @@ class SqliteDatabaseProvider implements DatabaseProvider {
         }
       }
     } catch (e, st) {
-      InspectorInternalLog.error('sqlite', '扫描数据库目录失败: $e', error: e, stackTrace: st);
+      InspectorInternalLog.error(
+        'sqlite',
+        '扫描数据库目录失败: $e',
+        error: e,
+        stackTrace: st,
+      );
     }
 
     return databases;
@@ -108,7 +124,12 @@ class SqliteDatabaseProvider implements DatabaseProvider {
           rowCount = await _getRowCount(db, tableName);
         } catch (e, st) {
           tableError = '读取表 $tableName 的 schema 失败: $e';
-          InspectorInternalLog.warning('sqlite', tableError, error: e, stackTrace: st);
+          InspectorInternalLog.warning(
+            'sqlite',
+            tableError,
+            error: e,
+            stackTrace: st,
+          );
         }
 
         tables.add(
@@ -123,7 +144,12 @@ class SqliteDatabaseProvider implements DatabaseProvider {
     } catch (e, st) {
       // 读取 sqlite_master 失败：整库 schema 不可用，报错交由调用方记录。
       // Reading sqlite_master failed: schema unavailable; caller logs it.
-      InspectorInternalLog.error('sqlite', '读取表列表失败: $e', error: e, stackTrace: st);
+      InspectorInternalLog.error(
+        'sqlite',
+        '读取表列表失败: $e',
+        error: e,
+        stackTrace: st,
+      );
       rethrow;
     }
 
@@ -272,7 +298,12 @@ class SqliteDatabaseProvider implements DatabaseProvider {
       try {
         await db.close();
       } catch (e, st) {
-        InspectorInternalLog.warning('sqlite', '关闭数据库连接失败: $e', error: e, stackTrace: st);
+        InspectorInternalLog.warning(
+          'sqlite',
+          '关闭数据库连接失败: $e',
+          error: e,
+          stackTrace: st,
+        );
       }
     }
     _connections.clear();

--- a/lib/src/ui/database_viewer.dart
+++ b/lib/src/ui/database_viewer.dart
@@ -656,6 +656,8 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
                   style: TextStyle(
                     color: isSelected
                         ? InspectorColors.accent
+                        : table.error != null
+                        ? Colors.red
                         : InspectorColors.textPrimary,
                     fontSize: 12,
                     fontWeight: isSelected ? FontWeight.w500 : FontWeight.w400,
@@ -663,21 +665,24 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: InspectorColors.border,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Text(
-                  '${table.rowCount}',
-                  style: TextStyle(
-                    color: InspectorColors.accent,
-                    fontSize: 10,
-                    fontWeight: FontWeight.w600,
+              if (table.error != null)
+                Icon(Icons.error_outline, size: 14, color: Colors.red)
+              else
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: InspectorColors.border,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    '${table.rowCount}',
+                    style: TextStyle(
+                      color: InspectorColors.accent,
+                      fontSize: 10,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
-              ),
             ],
           ),
         ),
@@ -692,6 +697,50 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
         child: CircularProgressIndicator(
           color: InspectorColors.accent,
           strokeWidth: 2,
+        ),
+      );
+    }
+
+    // 查询失败：渲染错误态 + 重试按钮，而不是伪装成空列表。
+    // Query failed: render an error state with retry, not a fake empty list.
+    if (_tableData!.hasError) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline, size: 36, color: Colors.red),
+              const SizedBox(height: 12),
+              Text(
+                '查询失败',
+                style: TextStyle(
+                  color: InspectorColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                _tableData!.error!,
+                style: TextStyle(
+                  color: InspectorColors.textSecondary,
+                  fontSize: 11,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton.icon(
+                onPressed: () {
+                  if (_currentDatabase != null) {
+                    _loadTableData(_currentDatabase!.path, _selectedTable!.name);
+                  }
+                },
+                icon: const Icon(Icons.refresh_rounded, size: 16),
+                label: const Text('重试'),
+              ),
+            ],
+          ),
         ),
       );
     }

--- a/lib/src/ui/database_viewer.dart
+++ b/lib/src/ui/database_viewer.dart
@@ -669,7 +669,10 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
                 Icon(Icons.error_outline, size: 14, color: Colors.red)
               else
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: InspectorColors.border,
                     borderRadius: BorderRadius.circular(4),
@@ -733,7 +736,10 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
               ElevatedButton.icon(
                 onPressed: () {
                   if (_currentDatabase != null) {
-                    _loadTableData(_currentDatabase!.path, _selectedTable!.name);
+                    _loadTableData(
+                      _currentDatabase!.path,
+                      _selectedTable!.name,
+                    );
                   }
                 },
                 icon: const Icon(Icons.refresh_rounded, size: 16),

--- a/lib/src/ui/network_viewer.dart
+++ b/lib/src/ui/network_viewer.dart
@@ -18,9 +18,26 @@ class NetworkViewer extends StatefulWidget {
 class _NetworkViewerState extends State<NetworkViewer> {
   String _searchKeyword = '';
   final TextEditingController _searchController = TextEditingController();
-  NetworkRequest? _selectedRequest;
+  // 只保存选中请求的 id，每次从服务持有的实时列表中解析。
+  // 这样当请求对象被更新（如响应体到达 / copyWith 替换）时，
+  // 详情页自动显示最新数据，避免持有过期引用导致的 UI 卡在旧状态。
+  // Only keep the selected request's id and resolve it from the live list each
+  // time. This keeps the detail view in sync when the request is replaced via
+  // copyWith (e.g. response body arrives), avoiding a stale reference.
+  String? _selectedRequestId;
   RequestInterceptorRule? _editingRule;
   bool _showInterceptorPanel = false;
+
+  /// 从实时列表中解析当前选中的请求；找不到（已被淘汰）时返回 null。
+  /// Resolves the selected request from the live list; null if evicted.
+  NetworkRequest? get _selectedRequest {
+    if (_selectedRequestId == null) return null;
+    final list = InspectorService.instance.networkRequests;
+    for (final r in list) {
+      if (r.id == _selectedRequestId) return r;
+    }
+    return null;
+  }
 
   @override
   void dispose() {
@@ -29,7 +46,8 @@ class _NetworkViewerState extends State<NetworkViewer> {
   }
 
   void _showInterceptorEditor() {
-    final request = _selectedRequest!;
+    final request = _selectedRequest;
+    if (request == null) return;
     final existingRule = InspectorService.instance.findMatchingRule(
       request.url,
       request.method,
@@ -127,7 +145,7 @@ class _NetworkViewerState extends State<NetworkViewer> {
                   tooltip: 'Back',
                   onTap: () {
                     setState(() {
-                      _selectedRequest = null;
+                      _selectedRequestId = null;
                       _showInterceptorPanel = false;
                     });
                   },
@@ -405,7 +423,7 @@ class _NetworkViewerState extends State<NetworkViewer> {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => setState(() => _selectedRequest = request),
+        onTap: () => setState(() => _selectedRequestId = request.id),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(

--- a/lib/src/utils/inspector_internal_log.dart
+++ b/lib/src/utils/inspector_internal_log.dart
@@ -61,8 +61,7 @@ class InspectorInternalLog {
   static final List<InternalLogEntry> _entries = [];
 
   /// Read-only view of the most recent diagnostic entries (oldest first).
-  static List<InternalLogEntry> get entries =>
-      List.unmodifiable(_entries);
+  static List<InternalLogEntry> get entries => List.unmodifiable(_entries);
 
   /// Whether any [InternalLogLevel.error] entry has been recorded.
   static bool get hasErrors =>
@@ -108,14 +107,30 @@ class InspectorInternalLog {
   /// Convenience helpers.
   static void debug(String tag, String message) =>
       log(tag, message, level: InternalLogLevel.debug);
-  static void warning(String tag, String message,
-          {Object? error, StackTrace? stackTrace}) =>
-      log(tag, message,
-          level: InternalLogLevel.warning, error: error, stackTrace: stackTrace);
-  static void error(String tag, String message,
-          {Object? error, StackTrace? stackTrace}) =>
-      log(tag, message,
-          level: InternalLogLevel.error, error: error, stackTrace: stackTrace);
+  static void warning(
+    String tag,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) => log(
+    tag,
+    message,
+    level: InternalLogLevel.warning,
+    error: error,
+    stackTrace: stackTrace,
+  );
+  static void error(
+    String tag,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) => log(
+    tag,
+    message,
+    level: InternalLogLevel.error,
+    error: error,
+    stackTrace: stackTrace,
+  );
 
   /// Clear the buffer (primarily for tests).
   static void clear() => _entries.clear();

--- a/lib/src/utils/inspector_internal_log.dart
+++ b/lib/src/utils/inspector_internal_log.dart
@@ -1,0 +1,122 @@
+import 'dart:developer' as developer;
+
+/// Severity levels for internal diagnostic logging.
+enum InternalLogLevel {
+  /// Verbose diagnostic detail. Only visible at fine-grained log levels.
+  debug,
+
+  /// Recoverable issue worth surfacing to developers (e.g. a query failed but
+  /// the app keeps running). This is the level most internal warnings use.
+  warning,
+
+  /// Hard failure that prevents a feature from working (e.g. cannot open the
+  /// inspector database).
+  error,
+}
+
+/// A single internal diagnostic record kept for in-inspector debugging.
+class InternalLogEntry {
+  const InternalLogEntry({
+    required this.time,
+    required this.level,
+    required this.tag,
+    required this.message,
+    this.error,
+    this.stackTrace,
+  });
+
+  final DateTime time;
+  final InternalLogLevel level;
+  final String tag;
+  final String message;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() {
+    final buf = StringBuffer()
+      ..write(time.toIso8601String())
+      ..write(' [')
+      ..write(level.name)
+      ..write('] ')
+      ..write(tag)
+      ..write(': ')
+      ..write(message);
+    if (error != null) buf.write(' ($error)');
+    return buf.toString();
+  }
+}
+
+/// Ring-buffer of internal diagnostic logs emitted by Zero Inspector Kit.
+///
+/// These logs never reach end-user-facing output by themselves. They are kept
+/// so the in-app console can show *why* something failed (e.g. a database query
+/// that was previously swallowed by a silent `catch (_)`), and are also sent to
+/// `dart:developer.log` in debug builds for console inspection.
+class InspectorInternalLog {
+  InspectorInternalLog._();
+
+  static const int _maxEntries = 200;
+
+  static final List<InternalLogEntry> _entries = [];
+
+  /// Read-only view of the most recent diagnostic entries (oldest first).
+  static List<InternalLogEntry> get entries =>
+      List.unmodifiable(_entries);
+
+  /// Whether any [InternalLogLevel.error] entry has been recorded.
+  static bool get hasErrors =>
+      _entries.any((e) => e.level == InternalLogLevel.error);
+
+  /// Emit a diagnostic log entry.
+  ///
+  /// In debug mode the entry is also forwarded to `dart:developer.log` so it
+  /// shows up in the IDE console / `flutter logs`. In release builds this is a
+  /// no-op for the console but the ring buffer is still retained (tree-shaken
+  /// caller sites aside) for the in-inspector view.
+  static void log(
+    String tag,
+    String message, {
+    InternalLogLevel level = InternalLogLevel.debug,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    _entries.add(
+      InternalLogEntry(
+        time: DateTime.now(),
+        level: level,
+        tag: tag,
+        message: message,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+    if (_entries.length > _maxEntries) {
+      _entries.removeAt(0);
+    }
+
+    if (level == InternalLogLevel.debug) return;
+    developer.log(
+      message,
+      name: 'ZeroInspectorKit.$tag',
+      error: error,
+      stackTrace: stackTrace,
+      level: level == InternalLogLevel.error ? 1000 : 900,
+    );
+  }
+
+  /// Convenience helpers.
+  static void debug(String tag, String message) =>
+      log(tag, message, level: InternalLogLevel.debug);
+  static void warning(String tag, String message,
+          {Object? error, StackTrace? stackTrace}) =>
+      log(tag, message,
+          level: InternalLogLevel.warning, error: error, stackTrace: stackTrace);
+  static void error(String tag, String message,
+          {Object? error, StackTrace? stackTrace}) =>
+      log(tag, message,
+          level: InternalLogLevel.error, error: error, stackTrace: stackTrace);
+
+  /// Clear the buffer (primarily for tests).
+  static void clear() => _entries.clear();
+}

--- a/lib/zero_inspector_kit.dart
+++ b/lib/zero_inspector_kit.dart
@@ -17,6 +17,7 @@ export 'src/ui/database_viewer.dart';
 export 'src/ui/route_viewer.dart';
 export 'src/ui/fps_viewer.dart';
 export 'src/utils/environment.dart';
+export 'src/utils/inspector_internal_log.dart';
 export 'src/utils/inspector_log.dart';
 export 'src/utils/memory_leak_tracking.dart';
 


### PR DESCRIPTION
## Summary

### 错误处理 / Error handling (P0-5)
- 新增 `InspectorInternalLog`（`lib/src/utils/inspector_internal_log.dart`）：debug-only 诊断日志环形缓冲（200 条）+ `debug/warning/error` 三级，debug 构建同时转发到 `dart:developer.log`。
- `sqlite_provider.dart` 中 `getDatabases` / `_getTables` / `_getColumns` / `_getRowCount` / `queryTable` / `dispose` 的全部静默 `catch (_)` 改为记录 `InspectorInternalLog` 并向上携带错误信息，不再吞掉真相。

### 模型 / Models
- `QueryResult` 新增 `error` 字段与 `hasError` getter，以及 `QueryResult.empty()` / `QueryResult.failure()` 工厂构造。
- `DatabaseInfo` / `TableInfo` 新增 `error` 字段：扫描失败（如无法打开 DB、读不到 schema）时记录原因，而非返回空列表。

### UI / 空态 vs 错误态
- `database_viewer`：数据库列表与表列表对 `error` 显示红色 `error_outline` 图标与提示；表数据视图区分**空态**与**错误态**，查询失败时展示错误文案 + **重试按钮**。

### 过期引用修复 / Stale reference (P1-8)
- `network_viewer`：详情页不再持有 `_selectedRequest` 对象引用，改为保存 `_selectedRequestId`，每次从 `InspectorService` 实时列表解析。请求被 `copyWith` 更新（响应体到达）或被容量淘汰后，详情页自动同步最新数据或回退到列表，避免 UI 卡在旧快照。

## 预期收益
- 调试工具的核心价值是"告诉开发者发生了什么"。此前查询/扫描失败会被静默吞掉，UI 显示误导性的空列表；现在错误明确呈现并可重试。
- 网络详情页在响应体异步到达后不再停留在"请求已发出但无响应"的旧状态。

## Test plan
- [x] `flutter analyze` 无问题（No issues found）
- [x] `flutter test` 全部通过（152 passed）
- [ ] 手动：打开数据库查看器，选一个损坏/无法打开的 `.db`，确认显示错误态而非空列表，且重试按钮可点
- [ ] 手动：发起一个网络请求，等响应返回后确认详情页自动刷新出 Response Body

## Notes
- 向后兼容：`QueryResult` / `DatabaseInfo` / `TableInfo` 的新字段均为可选命名参数，不改变既有构造调用；`InspectorInternalLog` 为新增公开工具，不影响已有公开 API。无需 major 版本。
- 仅替换了 `sqlite_provider` 与 UI 层的静默 catch；`http_interceptor`、`memory_inspector_service` 等其余 40+ 处静默 catch 留待后续批次
