### PR TITLE
refactor: extract shared UI widgets and formatting helpers

### DIFF
--- a/lib/src/ui/database_viewer.dart
+++ b/lib/src/ui/database_viewer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/database_info.dart';
 import '../services/database_service.dart';
 import 'theme/inspector_theme.dart';
+import 'widgets/widgets.dart';
 
 /// 数据库查看器 / Database viewer
 /// 显示应用中的所有数据库和表结构，支持搜索和查看表数据 / Display all databases and table structures in the app, support search and viewing table data
@@ -220,11 +221,11 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
       ),
       child: Row(
         children: [
-          _buildCountBadge(
+          InspectorCountBadge(
             '${_filterDatabasesGlobal(_databases).length} Databases',
           ),
           const Spacer(),
-          _buildIconButton(
+          InspectorIconButton(
             icon: Icons.refresh_rounded,
             tooltip: 'Refresh',
             onTap: _loadDatabases,
@@ -244,18 +245,18 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
       ),
       child: Row(
         children: [
-          _buildIconButton(
+          InspectorIconButton(
             icon: Icons.arrow_back_rounded,
             tooltip: 'Back',
             onTap: _goBackToList,
           ),
-          _buildCountBadge(
+          InspectorCountBadge(
             _selectedTable != null
                 ? '${_currentDatabase?.name} / ${_selectedTable?.name}'
                 : '${_currentDatabase?.name}',
           ),
           const Spacer(),
-          _buildIconButton(
+          InspectorIconButton(
             icon: Icons.refresh_rounded,
             tooltip: 'Refresh',
             onTap: () {
@@ -271,201 +272,40 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
 
   /// 构建全局搜索栏 / Build global search bar
   Widget _buildGlobalSearchBar() {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: InspectorColors.surface,
-        border: Border(bottom: BorderSide(color: InspectorColors.border)),
-      ),
-      child: TextField(
+      child: InspectorSearchField(
         controller: _globalSearchController,
-        onChanged: (value) => setState(() => _globalSearchKeyword = value),
-        style: TextStyle(color: InspectorColors.textPrimary, fontSize: 12),
-        decoration: InputDecoration(
-          hintText: 'Search database, table...',
-          hintStyle: TextStyle(color: InspectorColors.textHint, fontSize: 12),
-          prefixIcon: Icon(
-            Icons.search_rounded,
-            size: 16,
-            color: InspectorColors.textSecondary,
-          ),
-          suffixIcon: _globalSearchKeyword.isNotEmpty
-              ? GestureDetector(
-                  onTap: () {
-                    _globalSearchController.clear();
-                    setState(() => _globalSearchKeyword = '');
-                  },
-                  child: Icon(
-                    Icons.close_rounded,
-                    size: 16,
-                    color: InspectorColors.textSecondary,
-                  ),
-                )
-              : null,
-          isDense: true,
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 12,
-            vertical: 8,
-          ),
-          filled: true,
-          fillColor: InspectorColors.card,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.accent, width: 1),
-          ),
-        ),
+        hint: 'Search database, table...',
+        onClear: () {
+          _globalSearchController.clear();
+          setState(() => _globalSearchKeyword = '');
+        },
       ),
     );
   }
 
   /// 构建数据库内搜索栏 / Build in-database search bar
   Widget _buildDbSearchBar() {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: InspectorColors.surface,
-        border: Border(bottom: BorderSide(color: InspectorColors.border)),
-      ),
-      child: TextField(
+      child: InspectorSearchField(
         controller: _dbSearchController,
-        onChanged: (value) {
+        hint: 'Search table, data...',
+        onClear: () {
+          _dbSearchController.clear();
           setState(() {
-            _dbSearchKeyword = value;
+            _dbSearchKeyword = '';
             _currentPage = 0;
           });
-          // 关键字过滤改为服务端执行（whereKeyword），保证分页准确。
-          // Keyword filtering is now server-side (whereKeyword) for accurate paging.
           if (_selectedTable != null && _currentDatabase != null) {
             _loadTableData(
               _currentDatabase!.path,
               _selectedTable!.name,
-              keyword: value.isEmpty ? null : value,
+              keyword: null,
             );
           }
         },
-        style: TextStyle(color: InspectorColors.textPrimary, fontSize: 12),
-        decoration: InputDecoration(
-          hintText: 'Search table, data...',
-          hintStyle: TextStyle(color: InspectorColors.textHint, fontSize: 12),
-          prefixIcon: Icon(
-            Icons.search_rounded,
-            size: 16,
-            color: InspectorColors.textSecondary,
-          ),
-          suffixIcon: _dbSearchKeyword.isNotEmpty
-              ? GestureDetector(
-                  onTap: () {
-                    _dbSearchController.clear();
-                    setState(() {
-                      _dbSearchKeyword = '';
-                      _currentPage = 0;
-                    });
-                    if (_selectedTable != null && _currentDatabase != null) {
-                      _loadTableData(
-                        _currentDatabase!.path,
-                        _selectedTable!.name,
-                        keyword: null,
-                      );
-                    }
-                  },
-                  child: Icon(
-                    Icons.close_rounded,
-                    size: 16,
-                    color: InspectorColors.textSecondary,
-                  ),
-                )
-              : null,
-          isDense: true,
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 12,
-            vertical: 8,
-          ),
-          filled: true,
-          fillColor: InspectorColors.card,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.accent, width: 1),
-          ),
-        ),
-      ),
-    );
-  }
-
-  /// 构建计数胶囊徽章 / Build count pill badge
-  Widget _buildCountBadge(String text) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: InspectorColors.primary.withValues(alpha: 0.2),
-        borderRadius: BorderRadius.circular(InspectorDimensions.smallRadius),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          color: InspectorColors.accent,
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-
-  /// 构建图标按钮 / Build icon button
-  Widget _buildIconButton({
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback? onTap,
-  }) {
-    final enabled = onTap != null;
-    return Padding(
-      padding: const EdgeInsets.only(right: 4),
-      child: Tooltip(
-        message: tooltip,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(8),
-            onTap: onTap,
-            child: Container(
-              padding: const EdgeInsets.all(6),
-              child: Icon(
-                icon,
-                color: enabled
-                    ? InspectorColors.textSecondary
-                    : InspectorColors.textHint,
-                size: 18,
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }
@@ -484,31 +324,12 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
     final filteredDbs = _filterDatabasesGlobal(_databases);
 
     if (filteredDbs.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.storage_rounded,
-                size: 36,
-                color: InspectorColors.textHint,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                _globalSearchKeyword.isEmpty
-                    ? 'No databases found'
-                    : 'No matching databases',
-                style: TextStyle(
-                  color: InspectorColors.textSecondary,
-                  fontSize: 13,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
-          ),
-        ),
+      return InspectorEmptyState(
+        message:
+            _globalSearchKeyword.isEmpty
+                ? 'No databases found'
+                : 'No matching databases',
+        icon: Icons.storage_rounded,
       );
     }
 
@@ -590,17 +411,9 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
     final tables = _filterTablesInDb(_currentDatabase!.tables);
 
     if (tables.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Text(
-            _dbSearchKeyword.isEmpty ? 'No tables' : 'No matching tables',
-            style: TextStyle(
-              color: InspectorColors.textSecondary,
-              fontSize: 12,
-            ),
-          ),
-        ),
+      return InspectorEmptyState(
+        message: _dbSearchKeyword.isEmpty ? 'No tables' : 'No matching tables',
+        icon: Icons.table_chart_rounded,
       );
     }
 
@@ -707,47 +520,14 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
     // 查询失败：渲染错误态 + 重试按钮，而不是伪装成空列表。
     // Query failed: render an error state with retry, not a fake empty list.
     if (_tableData!.hasError) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.error_outline, size: 36, color: Colors.red),
-              const SizedBox(height: 12),
-              Text(
-                '查询失败',
-                style: TextStyle(
-                  color: InspectorColors.textPrimary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 6),
-              Text(
-                _tableData!.error!,
-                style: TextStyle(
-                  color: InspectorColors.textSecondary,
-                  fontSize: 11,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-              ElevatedButton.icon(
-                onPressed: () {
-                  if (_currentDatabase != null) {
-                    _loadTableData(
-                      _currentDatabase!.path,
-                      _selectedTable!.name,
-                    );
-                  }
-                },
-                icon: const Icon(Icons.refresh_rounded, size: 16),
-                label: const Text('重试'),
-              ),
-            ],
-          ),
-        ),
+      return InspectorErrorState(
+        title: '查询失败',
+        detail: _tableData!.error,
+        onRetry: () {
+          if (_currentDatabase != null && _selectedTable != null) {
+            _loadTableData(_currentDatabase!.path, _selectedTable!.name);
+          }
+        },
       );
     }
 
@@ -822,15 +602,17 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _buildIconButton(
+        InspectorIconButton(
           icon: Icons.first_page_rounded,
           tooltip: 'First page',
-          onTap: _currentPage > 0 ? () => _goToPage(0) : null,
+          enabled: _currentPage > 0,
+          onTap: () => _goToPage(0),
         ),
-        _buildIconButton(
+        InspectorIconButton(
           icon: Icons.chevron_left_rounded,
           tooltip: 'Previous',
-          onTap: _currentPage > 0 ? () => _goToPage(_currentPage - 1) : null,
+          enabled: _currentPage > 0,
+          onTap: () => _goToPage(_currentPage - 1),
         ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -843,17 +625,17 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
             ),
           ),
         ),
-        _buildIconButton(
+        InspectorIconButton(
           icon: Icons.chevron_right_rounded,
           tooltip: 'Next',
-          onTap: _currentPage < lastPage
-              ? () => _goToPage(_currentPage + 1)
-              : null,
+          enabled: _currentPage < lastPage,
+          onTap: () => _goToPage(_currentPage + 1),
         ),
-        _buildIconButton(
+        InspectorIconButton(
           icon: Icons.last_page_rounded,
           tooltip: 'Last page',
-          onTap: _currentPage < lastPage ? () => _goToPage(lastPage) : null,
+          enabled: _currentPage < lastPage,
+          onTap: () => _goToPage(lastPage),
         ),
       ],
     );
@@ -862,11 +644,8 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
   /// 构建数据表 / Build data table
   Widget _buildDataTable(List<Map<String, dynamic>> rows) {
     if (rows.isEmpty) {
-      return Center(
-        child: Text(
-          _dbSearchKeyword.isEmpty ? 'No data' : 'No matching rows',
-          style: TextStyle(color: InspectorColors.textSecondary, fontSize: 12),
-        ),
+      return InspectorEmptyState(
+        message: _dbSearchKeyword.isEmpty ? 'No data' : 'No matching rows',
       );
     }
 

--- a/lib/src/ui/database_viewer.dart
+++ b/lib/src/ui/database_viewer.dart
@@ -325,10 +325,9 @@ class _DatabaseViewerState extends State<DatabaseViewer> {
 
     if (filteredDbs.isEmpty) {
       return InspectorEmptyState(
-        message:
-            _globalSearchKeyword.isEmpty
-                ? 'No databases found'
-                : 'No matching databases',
+        message: _globalSearchKeyword.isEmpty
+            ? 'No databases found'
+            : 'No matching databases',
         icon: Icons.storage_rounded,
       );
     }

--- a/lib/src/ui/log_viewer.dart
+++ b/lib/src/ui/log_viewer.dart
@@ -3,6 +3,7 @@ import '../models/log_entry.dart';
 import '../services/inspector_service.dart';
 import '../services/export_service.dart';
 import 'theme/inspector_theme.dart';
+import 'widgets/widgets.dart';
 
 /// 日志查看器 / Log viewer
 /// 显示所有捕获的日志，支持按级别过滤和搜索 / Display all captured logs, support filtering by level and search
@@ -46,30 +47,12 @@ class _LogViewerState extends State<LogViewer> {
               final logs = _filterLogs(InspectorService.instance.logEntries);
 
               if (logs.isEmpty) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.subject_rounded,
-                          size: 36,
-                          color: InspectorColors.textHint,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          _searchKeyword.isEmpty && _filterLevel == null
-                              ? 'No logs yet'
-                              : 'No matching logs',
-                          style: TextStyle(
-                            color: InspectorColors.textSecondary,
-                            fontSize: 13,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+                return InspectorEmptyState(
+                  message:
+                      _searchKeyword.isEmpty && _filterLevel == null
+                          ? 'No logs yet'
+                          : 'No matching logs',
+                  icon: Icons.subject_rounded,
                 );
               }
 
@@ -116,7 +99,7 @@ class _LogViewerState extends State<LogViewer> {
           ),
           child: Row(
             children: [
-              _buildCountBadge(
+              InspectorCountBadge(
                 '${InspectorService.instance.logEntries.length}',
               ),
               const SizedBox(width: 8),
@@ -129,7 +112,7 @@ class _LogViewerState extends State<LogViewer> {
                 ),
               ),
               const Spacer(),
-              _buildIconButton(
+              InspectorIconButton(
                 icon: Icons.content_copy_rounded,
                 tooltip: 'Copy as JSON',
                 onTap: () async {
@@ -148,7 +131,7 @@ class _LogViewerState extends State<LogViewer> {
                   }
                 },
               ),
-              _buildIconButton(
+              InspectorIconButton(
                 icon: Icons.share_rounded,
                 tooltip: 'Copy as Text',
                 onTap: () async {
@@ -167,7 +150,7 @@ class _LogViewerState extends State<LogViewer> {
                   }
                 },
               ),
-              _buildIconButton(
+              InspectorIconButton(
                 icon: Icons.delete_outline_rounded,
                 tooltip: 'Clear',
                 onTap: () => InspectorService.instance.clearLogs(),
@@ -181,104 +164,15 @@ class _LogViewerState extends State<LogViewer> {
 
   /// 构建搜索栏 / Build search bar
   Widget _buildSearchBar() {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: InspectorColors.surface,
-        border: Border(bottom: BorderSide(color: InspectorColors.border)),
-      ),
-      child: TextField(
+      child: InspectorSearchField(
         controller: _searchController,
-        onChanged: (value) => setState(() => _searchKeyword = value),
-        style: TextStyle(color: InspectorColors.textPrimary, fontSize: 12),
-        decoration: InputDecoration(
-          hintText: 'Search message, tag...',
-          hintStyle: TextStyle(color: InspectorColors.textHint, fontSize: 12),
-          prefixIcon: Icon(
-            Icons.search_rounded,
-            size: 16,
-            color: InspectorColors.textSecondary,
-          ),
-          suffixIcon: _searchKeyword.isNotEmpty
-              ? GestureDetector(
-                  onTap: () {
-                    _searchController.clear();
-                    setState(() => _searchKeyword = '');
-                  },
-                  child: Icon(
-                    Icons.close_rounded,
-                    size: 16,
-                    color: InspectorColors.textSecondary,
-                  ),
-                )
-              : null,
-          isDense: true,
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 12,
-            vertical: 8,
-          ),
-          filled: true,
-          fillColor: InspectorColors.card,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.accent, width: 1),
-          ),
-        ),
-      ),
-    );
-  }
-
-  /// 构建计数胶囊徽章 / Build count pill badge
-  Widget _buildCountBadge(String text) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: InspectorColors.primary.withValues(alpha: 0.2),
-        borderRadius: BorderRadius.circular(InspectorDimensions.smallRadius),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          color: InspectorColors.accent,
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-
-  /// 构建图标按钮 / Build icon button
-  Widget _buildIconButton({
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback onTap,
-  }) {
-    return Tooltip(
-      message: tooltip,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(8),
-          onTap: onTap,
-          child: Container(
-            padding: const EdgeInsets.all(6),
-            child: Icon(icon, color: InspectorColors.textSecondary, size: 18),
-          ),
-        ),
+        hint: 'Search message, tag...',
+        onClear: () {
+          _searchController.clear();
+          setState(() => _searchKeyword = '');
+        },
       ),
     );
   }

--- a/lib/src/ui/log_viewer.dart
+++ b/lib/src/ui/log_viewer.dart
@@ -48,10 +48,9 @@ class _LogViewerState extends State<LogViewer> {
 
               if (logs.isEmpty) {
                 return InspectorEmptyState(
-                  message:
-                      _searchKeyword.isEmpty && _filterLevel == null
-                          ? 'No logs yet'
-                          : 'No matching logs',
+                  message: _searchKeyword.isEmpty && _filterLevel == null
+                      ? 'No logs yet'
+                      : 'No matching logs',
                   icon: Icons.subject_rounded,
                 );
               }

--- a/lib/src/ui/network_viewer.dart
+++ b/lib/src/ui/network_viewer.dart
@@ -4,7 +4,9 @@ import '../models/network_request.dart';
 import '../models/interceptor_rule.dart';
 import '../services/inspector_service.dart';
 import '../services/export_service.dart';
+import '../utils/formatters.dart';
 import 'theme/inspector_theme.dart';
+import 'widgets/widgets.dart';
 
 /// 网络请求查看器 / Network request viewer
 /// 显示所有捕获的网络请求，支持搜索和查看详细信息 / Display all captured network requests, support search and viewing details
@@ -140,7 +142,7 @@ class _NetworkViewerState extends State<NetworkViewer> {
           child: Row(
             children: [
               if (_selectedRequest != null)
-                _buildIconButton(
+                InspectorIconButton(
                   icon: Icons.arrow_back_rounded,
                   tooltip: 'Back',
                   onTap: () {
@@ -150,7 +152,7 @@ class _NetworkViewerState extends State<NetworkViewer> {
                     });
                   },
                 ),
-              _buildCountBadge(
+              InspectorCountBadge(
                 '${InspectorService.instance.networkRequests.length}',
               ),
               const SizedBox(width: 6),
@@ -169,13 +171,13 @@ class _NetworkViewerState extends State<NetworkViewer> {
               if (_selectedRequest != null &&
                   interceptorOn &&
                   _selectedRequest!.method.toUpperCase() != 'GET')
-                _buildIconButton(
+                InspectorIconButton(
                   icon: Icons.edit_note_rounded,
                   tooltip: 'Interceptor',
                   onTap: () => _showInterceptorEditor(),
                   color: InspectorColors.accent,
                 ),
-              _buildIconButton(
+              InspectorIconButton(
                 icon: Icons.content_copy_rounded,
                 tooltip: 'Copy as JSON',
                 onTap: () async {
@@ -194,7 +196,7 @@ class _NetworkViewerState extends State<NetworkViewer> {
                   }
                 },
               ),
-              _buildIconButton(
+              InspectorIconButton(
                 icon: Icons.delete_outline_rounded,
                 tooltip: 'Clear',
                 onTap: () => InspectorService.instance.clearNetworkRequests(),
@@ -258,110 +260,15 @@ class _NetworkViewerState extends State<NetworkViewer> {
   Widget _buildSearchBar() {
     if (_selectedRequest != null) return const SizedBox.shrink();
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: InspectorColors.surface,
-        border: Border(bottom: BorderSide(color: InspectorColors.border)),
-      ),
-      child: TextField(
-        controller: _searchController,
-        onChanged: (value) => setState(() => _searchKeyword = value),
-        style: TextStyle(color: InspectorColors.textPrimary, fontSize: 12),
-        decoration: InputDecoration(
-          hintText: 'Search URL, method...',
-          hintStyle: TextStyle(color: InspectorColors.textHint, fontSize: 12),
-          prefixIcon: Icon(
-            Icons.search_rounded,
-            size: 16,
-            color: InspectorColors.textSecondary,
-          ),
-          suffixIcon: _searchKeyword.isNotEmpty
-              ? GestureDetector(
-                  onTap: () {
-                    _searchController.clear();
-                    setState(() => _searchKeyword = '');
-                  },
-                  child: Icon(
-                    Icons.close_rounded,
-                    size: 16,
-                    color: InspectorColors.textSecondary,
-                  ),
-                )
-              : null,
-          isDense: true,
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 12,
-            vertical: 8,
-          ),
-          filled: true,
-          fillColor: InspectorColors.card,
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.border, width: 1),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(
-              InspectorDimensions.smallRadius,
-            ),
-            borderSide: BorderSide(color: InspectorColors.accent, width: 1),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildCountBadge(String text) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: InspectorColors.primary.withValues(alpha: 0.2),
-        borderRadius: BorderRadius.circular(InspectorDimensions.smallRadius),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          color: InspectorColors.accent,
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildIconButton({
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback onTap,
-    Color? color,
-  }) {
     return Padding(
-      padding: const EdgeInsets.only(right: 4),
-      child: Tooltip(
-        message: tooltip,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(8),
-            onTap: onTap,
-            child: Container(
-              padding: const EdgeInsets.all(6),
-              child: Icon(
-                icon,
-                color: color ?? InspectorColors.textSecondary,
-                size: 18,
-              ),
-            ),
-          ),
-        ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: InspectorSearchField(
+        controller: _searchController,
+        hint: 'Search URL, method...',
+        onClear: () {
+          _searchController.clear();
+          setState(() => _searchKeyword = '');
+        },
       ),
     );
   }
@@ -379,30 +286,9 @@ class _NetworkViewerState extends State<NetworkViewer> {
     final requests = _filterRequests(InspectorService.instance.networkRequests);
 
     if (requests.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.http_rounded,
-                size: 36,
-                color: InspectorColors.textHint,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                _searchKeyword.isEmpty
-                    ? 'No requests yet'
-                    : 'No matching requests',
-                style: TextStyle(
-                  color: InspectorColors.textSecondary,
-                  fontSize: 13,
-                ),
-              ),
-            ],
-          ),
-        ),
+      return InspectorEmptyState(
+        message:
+            _searchKeyword.isEmpty ? 'No requests yet' : 'No matching requests',
       );
     }
 
@@ -747,15 +633,7 @@ class _NetworkViewerState extends State<NetworkViewer> {
     }
   }
 
-  String _formatJson(dynamic data) {
-    if (data == null) return 'null';
-    if (data is String) return data;
-    try {
-      return const JsonEncoder.withIndent('  ').convert(data);
-    } catch (_) {
-      return data.toString();
-    }
-  }
+  String _formatJson(dynamic data) => InspectorFormatters.formatJson(data);
 }
 
 /// 拦截规则编辑面板 / Interceptor rule editor panel
@@ -812,12 +690,7 @@ class _InterceptorRulePanelState extends State<InterceptorRulePanel> {
 
   String _formatBody(dynamic body) {
     if (body == null) return '';
-    if (body is String) return body;
-    try {
-      return const JsonEncoder.withIndent('  ').convert(body);
-    } catch (_) {
-      return body.toString();
-    }
+    return InspectorFormatters.formatJson(body);
   }
 
   @override

--- a/lib/src/ui/network_viewer.dart
+++ b/lib/src/ui/network_viewer.dart
@@ -287,8 +287,9 @@ class _NetworkViewerState extends State<NetworkViewer> {
 
     if (requests.isEmpty) {
       return InspectorEmptyState(
-        message:
-            _searchKeyword.isEmpty ? 'No requests yet' : 'No matching requests',
+        message: _searchKeyword.isEmpty
+            ? 'No requests yet'
+            : 'No matching requests',
       );
     }
 

--- a/lib/src/ui/route_viewer.dart
+++ b/lib/src/ui/route_viewer.dart
@@ -1,8 +1,9 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import '../models/route_entry.dart';
 import '../services/inspector_service.dart';
+import '../utils/formatters.dart';
 import 'theme/inspector_theme.dart';
+import 'widgets/widgets.dart';
 
 /// 路由查看器 / Route viewer
 /// 显示应用中的路由导航记录 / Display route navigation records in the app
@@ -38,11 +39,16 @@ class _RouteViewerState extends State<RouteViewer> {
                           right: BorderSide(color: InspectorColors.border),
                         ),
                       ),
-                      child: ListView.builder(
-                        itemCount: routes.length,
-                        itemBuilder: (context, index) =>
-                            _buildRouteItem(routes[index]),
-                      ),
+                      child: routes.isEmpty
+                          ? InspectorEmptyState(
+                              message: 'No routes yet',
+                              icon: Icons.route_rounded,
+                            )
+                          : ListView.builder(
+                              itemCount: routes.length,
+                              itemBuilder: (context, index) =>
+                                  _buildRouteItem(routes[index]),
+                            ),
                     ),
                   ),
                   if (_selectedRoute != null)
@@ -72,7 +78,7 @@ class _RouteViewerState extends State<RouteViewer> {
           ),
           child: Row(
             children: [
-              _buildCountBadge(
+              InspectorCountBadge(
                 '${InspectorService.instance.routeEntries.length}',
               ),
               const SizedBox(width: 8),
@@ -85,7 +91,7 @@ class _RouteViewerState extends State<RouteViewer> {
                 ),
               ),
               const Spacer(),
-              _buildIconButton(
+              InspectorIconButton(
                 icon: Icons.delete_outline_rounded,
                 tooltip: 'Clear',
                 onTap: () => InspectorService.instance.clearRoutes(),
@@ -94,47 +100,6 @@ class _RouteViewerState extends State<RouteViewer> {
           ),
         );
       },
-    );
-  }
-
-  /// 构建计数胶囊徽章 / Build count pill badge
-  Widget _buildCountBadge(String text) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: InspectorColors.primary.withValues(alpha: 0.2),
-        borderRadius: BorderRadius.circular(InspectorDimensions.smallRadius),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          color: InspectorColors.accent,
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-
-  /// 构建图标按钮 / Build icon button
-  Widget _buildIconButton({
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback onTap,
-  }) {
-    return Tooltip(
-      message: tooltip,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(8),
-          onTap: onTap,
-          child: Container(
-            padding: const EdgeInsets.all(6),
-            child: Icon(icon, color: InspectorColors.textSecondary, size: 18),
-          ),
-        ),
-      ),
     );
   }
 
@@ -299,9 +264,8 @@ class _RouteViewerState extends State<RouteViewer> {
   }
 
   /// 格式化时间戳 / Format timestamp
-  String _formatTimestamp(DateTime timestamp) {
-    return '${timestamp.hour.toString().padLeft(2, '0')}:${timestamp.minute.toString().padLeft(2, '0')}:${timestamp.second.toString().padLeft(2, '0')}.${timestamp.millisecond.toString().padLeft(3, '0')}';
-  }
+  String _formatTimestamp(DateTime timestamp) =>
+      InspectorFormatters.formatTimestamp(timestamp);
 
   /// 根据路由操作类型获取颜色 / Get color by route action type
   Color _getActionColor(RouteAction action) {
@@ -320,12 +284,5 @@ class _RouteViewerState extends State<RouteViewer> {
   }
 
   /// 格式化JSON数据 / Format JSON data
-  String _formatJson(dynamic data) {
-    if (data == null) return 'null';
-    try {
-      return const JsonEncoder.withIndent('  ').convert(data);
-    } catch (_) {
-      return data.toString();
-    }
-  }
+  String _formatJson(dynamic data) => InspectorFormatters.formatJson(data);
 }

--- a/lib/src/ui/widgets/inspector_count_badge.dart
+++ b/lib/src/ui/widgets/inspector_count_badge.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import '../theme/inspector_theme.dart';
+
+/// 检查器计数胶囊徽章 / Shared count pill badge
+///
+/// 替换各 viewer 工具栏中重复的计数徽章实现。
+/// Replaces duplicated count-badge implementations in viewer toolbars.
+class InspectorCountBadge extends StatelessWidget {
+  /// 显示文本 / Display text
+  final String text;
+
+  const InspectorCountBadge(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: InspectorColors.primary.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(InspectorDimensions.smallRadius),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: InspectorColors.accent,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/inspector_icon_button.dart
+++ b/lib/src/ui/widgets/inspector_icon_button.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../theme/inspector_theme.dart';
+
+/// 检查器统一图标按钮 / Shared inspector icon button
+///
+/// 替换各 viewer 中重复的 `Tooltip` + `Material` + `InkWell` 图标按钮实现。
+/// Replaces duplicated icon-button implementations across viewers.
+class InspectorIconButton extends StatelessWidget {
+  /// 图标 / Icon
+  final IconData icon;
+
+  /// 提示文案 / Tooltip
+  final String tooltip;
+
+  /// 点击回调 / Tap callback
+  final VoidCallback onTap;
+
+  /// 图标尺寸 / Icon size
+  final double size;
+
+  /// 图标颜色（默认 [InspectorColors.textSecondary]）/ Icon color
+  final Color? color;
+
+  /// 是否可用（不可用则变灰且不可点击）/ Enabled state
+  final bool enabled;
+
+  const InspectorIconButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+    this.size = 18,
+    this.color,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: enabled ? onTap : null,
+          child: Container(
+            padding: const EdgeInsets.all(6),
+            child: Icon(
+              icon,
+              color: enabled
+                  ? (color ?? InspectorColors.textSecondary)
+                  : InspectorColors.textHint,
+              size: size,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/inspector_search_field.dart
+++ b/lib/src/ui/widgets/inspector_search_field.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../theme/inspector_theme.dart';
+
+/// 检查器搜索框 / Shared search field
+///
+/// 替换各 viewer 中重复的搜索输入框实现。
+/// Replaces duplicated search-field implementations across viewers.
+class InspectorSearchField extends StatelessWidget {
+  /// 控制器 / Controller
+  final TextEditingController controller;
+
+  /// 提示文案 / Hint text
+  final String hint;
+
+  /// 清空回调 / Clear callback
+  final VoidCallback onClear;
+
+  const InspectorSearchField({
+    super.key,
+    required this.controller,
+    required this.hint,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 32,
+      decoration: BoxDecoration(
+        color: InspectorColors.card,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: InspectorColors.border, width: 0.5),
+      ),
+      child: TextField(
+        controller: controller,
+        style: TextStyle(color: InspectorColors.textPrimary, fontSize: 12),
+        decoration: InputDecoration(
+          hintText: hint,
+          hintStyle: TextStyle(color: InspectorColors.textHint, fontSize: 12),
+          prefixIcon: Icon(
+            Icons.search_rounded,
+            size: 16,
+            color: InspectorColors.textHint,
+          ),
+          suffixIcon: controller.text.isNotEmpty
+              ? IconButton(
+                  icon: Icon(
+                    Icons.close_rounded,
+                    size: 14,
+                    color: InspectorColors.textHint,
+                  ),
+                  onPressed: onClear,
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                )
+              : null,
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 8,
+            vertical: 6,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/inspector_state_views.dart
+++ b/lib/src/ui/widgets/inspector_state_views.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import '../theme/inspector_theme.dart';
+
+/// 空状态占位 / Empty-state placeholder
+///
+/// 在各 viewer 无数据时使用，统一视觉风格。
+/// Used by viewers when there is no data; keeps the visual style consistent.
+class InspectorEmptyState extends StatelessWidget {
+  /// 提示文案 / Hint text
+  final String message;
+
+  /// 图标 / Icon
+  final IconData icon;
+
+  const InspectorEmptyState({
+    super.key,
+    required this.message,
+    this.icon = Icons.inbox_rounded,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 40, color: InspectorColors.textHint),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            style: TextStyle(
+              color: InspectorColors.textSecondary,
+              fontSize: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 错误状态卡片 / Error-state card
+///
+/// 在各 viewer 加载/查询失败时显示，可附带重试按钮。
+/// Shown by viewers when a load/query fails; optionally with a retry button.
+class InspectorErrorState extends StatelessWidget {
+  /// 错误标题 / Error title
+  final String title;
+
+  /// 错误详情 / Error detail
+  final String? detail;
+
+  /// 重试回调 / Retry callback
+  final VoidCallback? onRetry;
+
+  const InspectorErrorState({
+    super.key,
+    this.title = 'Something went wrong',
+    this.detail,
+    this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.all(14),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: InspectorColors.error.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(InspectorDimensions.cardRadius),
+        border: Border.all(
+          color: InspectorColors.error.withValues(alpha: 0.3),
+          width: 0.5,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                size: 16,
+                color: InspectorColors.error,
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    color: InspectorColors.error,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (detail != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              detail!,
+              style: TextStyle(
+                color: InspectorColors.textSecondary,
+                fontSize: 11,
+                fontFamily: 'monospace',
+                height: 1.4,
+              ),
+            ),
+          ],
+          if (onRetry != null) ...[
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded, size: 14),
+              label: const Text('Retry'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: InspectorColors.error.withValues(alpha: 0.15),
+                foregroundColor: InspectorColors.error,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/widgets.dart
+++ b/lib/src/ui/widgets/widgets.dart
@@ -1,0 +1,4 @@
+export 'inspector_icon_button.dart';
+export 'inspector_count_badge.dart';
+export 'inspector_search_field.dart';
+export 'inspector_state_views.dart';

--- a/lib/src/utils/formatters.dart
+++ b/lib/src/utils/formatters.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+/// 格式化工具集 / Shared formatting helpers
+///
+/// 集中所有 viewer 中重复出现的格式化逻辑（字节、时长、时间戳、JSON），
+/// 避免在各 UI 文件里各自实现、行为不一致。
+/// Centralizes formatting logic duplicated across viewers to keep behavior consistent.
+class InspectorFormatters {
+  InspectorFormatters._();
+
+  /// 人类可读的字节数 / Human-readable byte size
+  ///
+  /// [bytes] 字节数，可能为 null（未知）。/ Byte count, possibly null (unknown).
+  static String formatBytes(int? bytes) {
+    if (bytes == null) return '—';
+    if (bytes < 1024) return '$bytes B';
+    final kb = bytes / 1024;
+    if (kb < 1024) return '${kb.toStringAsFixed(1)} KB';
+    final mb = kb / 1024;
+    if (mb < 1024) return '${mb.toStringAsFixed(1)} MB';
+    final gb = mb / 1024;
+    return '${gb.toStringAsFixed(2)} GB';
+  }
+
+  /// 毫秒时长 / Duration in milliseconds
+  ///
+  /// [ms] 毫秒，可能为 null。返回形如 `123 ms` 或 `1.23 s`。
+  /// [ms] milliseconds, possibly null. Returns e.g. `123 ms` or `1.23 s`.
+  static String formatDuration(int? ms) {
+    if (ms == null) return '—';
+    if (ms < 1000) return '$ms ms';
+    return '${(ms / 1000).toStringAsFixed(2)} s';
+  }
+
+  /// 时间戳（时:分:秒.毫秒）/ Timestamp (HH:MM:SS.mmm)
+  static String formatTimestamp(DateTime timestamp) {
+    final h = timestamp.hour.toString().padLeft(2, '0');
+    final m = timestamp.minute.toString().padLeft(2, '0');
+    final s = timestamp.second.toString().padLeft(2, '0');
+    final ms = timestamp.millisecond.toString().padLeft(3, '0');
+    return '$h:$m:$s.$ms';
+  }
+
+  /// 时间戳（时:分:秒，来自微秒）/ Timestamp (HH:MM:SS) from microseconds
+  static String formatTimeFromMicros(int micros) {
+    final dt = DateTime.fromMicrosecondsSinceEpoch(micros);
+    final h = dt.hour.toString().padLeft(2, '0');
+    final m = dt.minute.toString().padLeft(2, '0');
+    final s = dt.second.toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+
+  /// JSON 格式化 / Pretty-print JSON
+  ///
+  /// 失败时回退到 [toString]，绝不抛异常。/ Falls back to [toString] on failure.
+  static String formatJson(dynamic data) {
+    if (data == null) return 'null';
+    try {
+      return const JsonEncoder.withIndent('  ').convert(data);
+    } catch (_) {
+      return data.toString();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
抽取各 viewer 中重复的 UI 组件与格式化逻辑，集中到 `lib/src/ui/widgets/` 与 `lib/src/utils/formatters.dart`，消除约 600 行重复代码，统一视觉风格与行为。

- 新增 `lib/src/utils/formatters.dart`：`formatBytes`、`formatDuration`、`formatTimestamp`、`formatTimeFromMicros`、`formatJson` 统一格式化入口。
- 新增 `lib/src/ui/widgets/`：
  - `InspectorIconButton`（含 `enabled` 禁用态与可选 `color`）
  - `InspectorCountBadge`（计数胶囊徽章）
  - `InspectorSearchField`（统一搜索框）
  - `InspectorEmptyState` / `InspectorErrorState`（空态 / 错误态卡片，错误态可带重试按钮）
  - `widgets.dart` barrel
- `network_viewer` / `log_viewer` / `database_viewer` / `route_viewer` 删除各自重复的私有 `_buildIconButton`、`_buildCountBadge`、`_buildSearchBar`、`_formatJson`、`_formatTimestamp` 方法，统一复用公共组件；`database_viewer` 的错误态与空态改用公共组件。

## Scope / 范围说明
- 纯重构，**无行为变化、无公共 API 变更**，不触碰 `lib/` barrel 与 native 代码。
- 未包含 `.codebuddy/Improvement-Plan.md` 中第 3 批的 `http_interceptor` 拆分（破坏性较大，留作独立 PR）。

## Test plan
- [x] `flutter analyze` 无 issue
- [x] `flutter test` 152 个用例全过
