### PR TITLE
feat: add copy-as-cURL and alert rules with red-dot notifications

### DIFF
--- a/lib/src/models/alert_rule.dart
+++ b/lib/src/models/alert_rule.dart
@@ -1,0 +1,56 @@
+/// 告警规则类型 / Alert rule kinds
+enum AlertKind {
+  /// 网络响应状态码 >= 阈值（默认 500）/ HTTP status >= threshold (default 500)
+  httpStatus,
+
+  /// 网络耗时超过阈值（毫秒）/ Request duration exceeds threshold (ms)
+  requestDuration,
+
+  /// 日志级别达到阈值（ERROR 及以上）/ Log level reaches threshold (ERROR+)
+  logLevel,
+
+  /// 内存占用超过阈值（MB）/ Memory usage exceeds threshold (MB)
+  memoryMb,
+
+  /// FPS 低于阈值 / FPS drops below threshold
+  fpsLow,
+}
+
+/// 单条告警规则 / A single alert rule
+///
+/// 当采集数据命中 [kind] 且超过/达到 [threshold] 时触发告警。
+/// Fires when collected data matches [kind] and crosses [threshold].
+class AlertRule {
+  /// 唯一ID / Unique ID
+  final String id;
+
+  /// 规则类型 / Rule kind
+  final AlertKind kind;
+
+  /// 阈值 / Threshold value
+  final double threshold;
+
+  /// 是否启用 / Enabled
+  final bool enabled;
+
+  const AlertRule({
+    required this.id,
+    required this.kind,
+    required this.threshold,
+    this.enabled = true,
+  });
+
+  /// 默认规则集合：5xx、慢请求 1s、ERROR 日志、内存 200MB、FPS<50
+  /// Default rules: 5xx, slow request 1s, ERROR logs, 200MB memory, FPS<50
+  static const List<AlertRule> defaults = [
+    AlertRule(id: 'def-status', kind: AlertKind.httpStatus, threshold: 500),
+    AlertRule(
+      id: 'def-duration',
+      kind: AlertKind.requestDuration,
+      threshold: 1000,
+    ),
+    AlertRule(id: 'def-log', kind: AlertKind.logLevel, threshold: 4),
+    AlertRule(id: 'def-mem', kind: AlertKind.memoryMb, threshold: 200),
+    AlertRule(id: 'def-fps', kind: AlertKind.fpsLow, threshold: 50),
+  ];
+}

--- a/lib/src/services/alert_service.dart
+++ b/lib/src/services/alert_service.dart
@@ -1,0 +1,132 @@
+import 'dart:collection';
+import 'package:flutter/foundation.dart';
+import '../models/alert_rule.dart';
+import '../models/network_request.dart';
+import '../models/log_entry.dart';
+
+/// 告警服务 / Alert service
+///
+/// 在数据写入（网络/日志/内存/FPS）时被调用以检测是否命中规则。
+/// 命中的告警以 [AlertEvent] 形式入队，并通过 [unreadCount] 暴露未读数，
+/// 供悬浮球显示红点。告警列表有上限（环形缓冲），避免无限增长。
+/// Invoked on data write to detect rule hits. Hit events are queued and exposed
+/// via [unreadCount] for the floating button red dot. Bounded ring buffer.
+class AlertService {
+  AlertService._();
+
+  /// 单例实例 / Singleton instance
+  static final AlertService instance = AlertService._();
+
+  /// 告警事件环形缓冲上限 / Alert event ring buffer cap
+  static const int _maxEvents = 100;
+
+  /// 已启用的规则（默认内置）/ Enabled rules (defaults built-in)
+  final List<AlertRule> _rules = List.of(AlertRule.defaults);
+
+  /// 告警事件缓冲 / Alert event buffer
+  final ListQueue<AlertEvent> _events = ListQueue();
+
+  /// 未读告警数（供红点）/ Unread alert count (for red dot)
+  final ValueNotifier<int> unreadCount = ValueNotifier<int>(0);
+
+  /// 规则列表只读视图 / Read-only rule list
+  UnmodifiableListView<AlertRule> get rules => UnmodifiableListView(_rules);
+
+  /// 告警事件只读视图（最新在前）/ Read-only event view (newest first)
+  UnmodifiableListView<AlertEvent> get events => UnmodifiableListView(_events);
+
+  /// 获取/设置规则 / Get/set rules
+  void setRules(List<AlertRule> rules) {
+    _rules
+      ..clear()
+      ..addAll(rules);
+  }
+
+  /// 新增一条规则 / Add a rule
+  void addRule(AlertRule rule) => _rules.add(rule);
+
+  /// 移除规则 / Remove a rule
+  void removeRule(String id) => _rules.removeWhere((r) => r.id == id);
+
+  /// 清空未读 / Clear unread
+  void clearUnread() {
+    if (unreadCount.value != 0) unreadCount.value = 0;
+  }
+
+  /// 清空全部告警 / Clear all alerts
+  void clearAll() {
+    _events.clear();
+    unreadCount.value = 0;
+  }
+
+  /// 检测网络请求是否命中规则 / Check a network request against rules
+  void checkNetwork(NetworkRequest r) {
+    for (final rule in _rules) {
+      if (!rule.enabled || rule.kind != AlertKind.httpStatus) continue;
+      if (r.statusCode != null && r.statusCode! >= rule.threshold) {
+        _fire(r.url, 'HTTP ${r.statusCode} ${r.method}');
+      }
+    }
+    for (final rule in _rules) {
+      if (!rule.enabled || rule.kind != AlertKind.requestDuration) continue;
+      if (r.duration != null && r.duration! >= rule.threshold) {
+        _fire(r.url, 'Slow ${r.duration}ms ${r.method}');
+      }
+    }
+  }
+
+  /// 检测日志是否命中规则 / Check a log entry against rules
+  void checkLog(LogEntry e) {
+    for (final rule in _rules) {
+      if (!rule.enabled || rule.kind != AlertKind.logLevel) continue;
+      // ERROR=4, WTF=5 / LogLevel ordinal
+      if (e.level.index >= rule.threshold) {
+        _fire(e.tag ?? 'log', '${e.level.name}: ${e.message}');
+      }
+    }
+  }
+
+  /// 检测内存占用（MB）/ Check memory usage in MB
+  void checkMemory(double mb) {
+    for (final rule in _rules) {
+      if (!rule.enabled || rule.kind != AlertKind.memoryMb) continue;
+      if (mb >= rule.threshold) {
+        _fire('memory', '${mb.toStringAsFixed(0)} MB used');
+      }
+    }
+  }
+
+  /// 检测 FPS / Check FPS
+  void checkFps(double fps) {
+    for (final rule in _rules) {
+      if (!rule.enabled || rule.kind != AlertKind.fpsLow) continue;
+      if (fps > 0 && fps < rule.threshold) {
+        _fire('fps', 'FPS dropped to ${fps.toStringAsFixed(0)}');
+      }
+    }
+  }
+
+  /// 触发一条告警：入队并累加未读 / Fire an alert: enqueue and bump unread
+  void _fire(String source, String message) {
+    _events.addFirst(AlertEvent(source: source, message: message));
+    while (_events.length > _maxEvents) {
+      _events.removeLast();
+    }
+    unreadCount.value = unreadCount.value + 1;
+  }
+}
+
+/// 告警事件 / Alert event
+class AlertEvent {
+  /// 来源（url / memory / fps / log）/ Source
+  final String source;
+
+  /// 描述 / Description
+  final String message;
+
+  /// 触发时间 / Timestamp
+  final DateTime time;
+
+  AlertEvent({required this.source, required this.message})
+    : time = DateTime.now();
+}

--- a/lib/src/services/export_service.dart
+++ b/lib/src/services/export_service.dart
@@ -49,6 +49,30 @@ class ExportService {
     'requests': requests.map((e) => e.toJson()).toList(),
   });
 
+  /// 网络请求 → 复制为 cURL 命令 / Network request → cURL command
+  ///
+  /// 生成可直接粘贴到终端执行的 curl 命令（含 method、headers、body）。
+  /// Produces a ready-to-run curl command (method, headers, body included).
+  String toCurl(NetworkRequest r) {
+    final buf = StringBuffer()..write('curl -X ${r.method} ');
+    // URL（含单引号时转义）/ URL (escape single quotes)
+    final url = r.url.replaceAll("'", "%27");
+    buf.writeln("'$url' \\");
+    for (final e in (r.headers ?? {}).entries) {
+      final name = e.key.replaceAll('"', '\\"');
+      final value = e.value.replaceAll('"', '\\"');
+      buf.writeln('  -H "$name: $value" \\');
+    }
+    if (r.body != null) {
+      final body = r.body.toString().replaceAll('"', '\\"');
+      buf.writeln('  -d "$body" \\');
+    }
+    // 去掉末尾的续行符 / Trim trailing line-continuation
+    var out = buf.toString();
+    if (out.endsWith(' \\\n')) out = out.substring(0, out.length - 3);
+    return out;
+  }
+
   /// 网络请求 → CSV / Network to CSV
   /// 列：method,url,statusCode,durationMs,requestTime,hasBody,hasResponse
   String netToCsv(List<NetworkRequest> requests) {

--- a/lib/src/services/fps_service.dart
+++ b/lib/src/services/fps_service.dart
@@ -3,6 +3,7 @@ import 'dart:ui' show FramePhase;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
+import 'alert_service.dart';
 
 /// 帧耗时记录 / Frame duration record
 ///
@@ -244,6 +245,9 @@ class FpsService extends ChangeNotifier {
     if (_fpsHistory.length > 60) {
       _fpsHistory.removeAt(0);
     }
+
+    // 告警检测 / Alert check
+    AlertService.instance.checkFps(_currentFps);
 
     notifyListeners();
   }

--- a/lib/src/services/inspector_service.dart
+++ b/lib/src/services/inspector_service.dart
@@ -5,6 +5,7 @@ import '../models/network_request.dart';
 import '../models/log_entry.dart';
 import '../models/route_entry.dart';
 import '../models/interceptor_rule.dart';
+import 'alert_service.dart';
 
 /// 检查器服务，用于管理所有收集的数据 / Inspector service for managing all collected data
 ///
@@ -126,6 +127,7 @@ class InspectorService extends ChangeNotifier {
   void addNetworkRequest(NetworkRequest request) {
     _networkRequests.addFirst(request);
     _trimQueue(_networkRequests, _maxNetworkItems);
+    AlertService.instance.checkNetwork(request);
     _notifyThrottled();
   }
 
@@ -146,18 +148,18 @@ class InspectorService extends ChangeNotifier {
       final now = DateTime.now().millisecondsSinceEpoch;
       final responseTime = request.responseTime ?? now;
       final duration = responseTime - request.requestTime;
+      final updated = request.copyWith(
+        responseBody: responseBody ?? request.responseBody,
+        statusCode: statusCode ?? request.statusCode,
+        body: body ?? request.body,
+        responseTime: responseTime,
+        duration: duration,
+        maxBodyBytes: _maxBodyPreviewBytes,
+      );
       _networkRequests
         ..remove(request)
-        ..addFirst(
-          request.copyWith(
-            responseBody: responseBody ?? request.responseBody,
-            statusCode: statusCode ?? request.statusCode,
-            body: body ?? request.body,
-            responseTime: responseTime,
-            duration: duration,
-            maxBodyBytes: _maxBodyPreviewBytes,
-          ),
-        );
+        ..addFirst(updated);
+      AlertService.instance.checkNetwork(updated);
       _notifyThrottled();
     }
   }
@@ -167,6 +169,7 @@ class InspectorService extends ChangeNotifier {
   void addLogEntry(LogEntry entry) {
     _logEntries.addFirst(entry);
     _trimQueue(_logEntries, _maxLogItems);
+    AlertService.instance.checkLog(entry);
     _notifyThrottled();
   }
 

--- a/lib/src/services/memory_inspector_service.dart
+++ b/lib/src/services/memory_inspector_service.dart
@@ -10,6 +10,7 @@ import '../models/leak_record.dart';
 import '../models/memory_snapshot.dart';
 import '../platform/platform_channel.dart';
 import 'database_service.dart';
+import 'alert_service.dart';
 
 /// 内存检查服务 / Memory inspector service
 ///
@@ -620,6 +621,9 @@ class MemoryInspectorService extends ChangeNotifier {
     while (_memorySnapshots.length > _maxSnapshots) {
       _memorySnapshots.removeAt(0);
     }
+
+    // 告警检测：以进程 RSS（MB）为准 / Alert: use process RSS in MB
+    AlertService.instance.checkMemory(_currentProcessRss / (1024 * 1024));
 
     notifyListeners();
   }

--- a/lib/src/ui/alerts_viewer.dart
+++ b/lib/src/ui/alerts_viewer.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import '../services/alert_service.dart';
+import '../utils/formatters.dart';
+import 'theme/inspector_theme.dart';
+import 'widgets/widgets.dart';
+
+/// 告警查看器 / Alerts viewer
+///
+/// 展示命中规则的告警事件列表，并提供清空入口。
+/// Shows alert events that hit the rules, with a clear action.
+class AlertsViewer extends StatefulWidget {
+  const AlertsViewer({super.key});
+
+  @override
+  State<AlertsViewer> createState() => _AlertsViewerState();
+}
+
+class _AlertsViewerState extends State<AlertsViewer> {
+  @override
+  void initState() {
+    super.initState();
+    AlertService.instance.unreadCount.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    AlertService.instance.unreadCount.removeListener(_onChanged);
+    super.dispose();
+  }
+
+  void _onChanged() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) {
+    final alerts = AlertService.instance.events;
+    return Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          decoration: BoxDecoration(
+            color: InspectorColors.surface,
+            border: Border(bottom: BorderSide(color: InspectorColors.border)),
+          ),
+          child: Row(
+            children: [
+              InspectorCountBadge('${alerts.length}'),
+              const SizedBox(width: 8),
+              Text(
+                'Alerts',
+                style: TextStyle(
+                  color: InspectorColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const Spacer(),
+              InspectorIconButton(
+                icon: Icons.delete_outline_rounded,
+                tooltip: 'Clear',
+                onTap: () => AlertService.instance.clearAll(),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: alerts.isEmpty
+              ? const InspectorEmptyState(
+                  message: 'No alerts',
+                  icon: Icons.notifications_off_rounded,
+                )
+              : ListView.separated(
+                  itemCount: alerts.length,
+                  separatorBuilder: (_, _) =>
+                      Divider(color: InspectorColors.border, height: 1),
+                  itemBuilder: (context, index) {
+                    final e = alerts[index];
+                    return ListTile(
+                      dense: true,
+                      leading: Icon(
+                        Icons.warning_amber_rounded,
+                        color: InspectorColors.error,
+                        size: 18,
+                      ),
+                      title: Text(
+                        e.source,
+                        style: TextStyle(
+                          color: InspectorColors.textPrimary,
+                          fontSize: 12,
+                          fontFamily: 'monospace',
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      subtitle: Text(
+                        e.message,
+                        style: TextStyle(
+                          color: InspectorColors.textSecondary,
+                          fontSize: 11,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      trailing: Text(
+                        InspectorFormatters.formatTimestamp(e.time),
+                        style: TextStyle(
+                          color: InspectorColors.textHint,
+                          fontSize: 10,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/ui/floating_button.dart
+++ b/lib/src/ui/floating_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import '../services/alert_service.dart';
 import 'theme/inspector_theme.dart';
 import 'inspector_panel.dart';
 
@@ -99,6 +100,7 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
   @override
   void initState() {
     super.initState();
+    AlertService.instance.unreadCount.addListener(_onUnreadChanged);
     _breathController = AnimationController(
       duration: const Duration(seconds: 2),
       vsync: this,
@@ -123,10 +125,14 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
 
   @override
   void dispose() {
+    AlertService.instance.unreadCount.removeListener(_onUnreadChanged);
     _breathController.dispose();
     _dockController.dispose();
     super.dispose();
   }
+
+  /// 未读告警数变化 → 触发重绘红点 / Unread alert change → repaint red dot
+  void _onUnreadChanged() => setState(() {});
 
   @override
   Widget build(BuildContext context) {
@@ -182,14 +188,46 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
                   ],
                 ),
                 child: Center(
-                  child: Icon(
-                    _dockSide == _DockSide.left
-                        ? Icons.chevron_right_rounded
-                        : _dockSide == _DockSide.right
-                        ? Icons.chevron_left_rounded
-                        : Icons.bug_report_rounded,
-                    color: InspectorColors.textPrimary,
-                    size: InspectorDimensions.floatingButtonIconSize,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Icon(
+                        _dockSide == _DockSide.left
+                            ? Icons.chevron_right_rounded
+                            : _dockSide == _DockSide.right
+                            ? Icons.chevron_left_rounded
+                            : Icons.bug_report_rounded,
+                        color: InspectorColors.textPrimary,
+                        size: InspectorDimensions.floatingButtonIconSize,
+                      ),
+                      if (AlertService.instance.unreadCount.value > 0)
+                        Positioned(
+                          top: -4,
+                          right: -4,
+                          child: Container(
+                            padding: const EdgeInsets.all(3),
+                            decoration: const BoxDecoration(
+                              color: Colors.red,
+                              shape: BoxShape.circle,
+                            ),
+                            constraints: const BoxConstraints(
+                              minWidth: 12,
+                              minHeight: 12,
+                            ),
+                            child: Text(
+                              AlertService.instance.unreadCount.value
+                                  .clamp(0, 99)
+                                  .toString(),
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 9,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
                 ),
               ),
@@ -290,6 +328,8 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
     } else {
       _togglePanelInternal();
     }
+    // 打开面板即视为已读 / Opening the panel marks alerts as read
+    AlertService.instance.clearUnread();
   }
 
   /// 把小球从吸附状态平滑拉出到完整可见位置

--- a/lib/src/ui/floating_button.dart
+++ b/lib/src/ui/floating_button.dart
@@ -134,6 +134,31 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
   /// 未读告警数变化 → 触发重绘红点 / Unread alert change → repaint red dot
   void _onUnreadChanged() => setState(() {});
 
+  /// 球体中心内容：有未读告警时显示红色数字，否则显示默认图标。
+  /// Ball center: red count when unread, otherwise the default icon.
+  Widget _buildCenter() {
+    final unread = AlertService.instance.unreadCount.value;
+    if (unread <= 0) {
+      return Icon(
+        _dockSide == _DockSide.left
+            ? Icons.chevron_right_rounded
+            : _dockSide == _DockSide.right
+            ? Icons.chevron_left_rounded
+            : Icons.bug_report_rounded,
+        color: InspectorColors.textPrimary,
+        size: InspectorDimensions.floatingButtonIconSize,
+      );
+    }
+    return Text(
+      unread.clamp(0, 99).toString(),
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 16,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (kReleaseMode) return const SizedBox.shrink();
@@ -188,47 +213,11 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
                   ],
                 ),
                 child: Center(
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      Icon(
-                        _dockSide == _DockSide.left
-                            ? Icons.chevron_right_rounded
-                            : _dockSide == _DockSide.right
-                            ? Icons.chevron_left_rounded
-                            : Icons.bug_report_rounded,
-                        color: InspectorColors.textPrimary,
-                        size: InspectorDimensions.floatingButtonIconSize,
-                      ),
-                      if (AlertService.instance.unreadCount.value > 0)
-                        Positioned(
-                          top: -4,
-                          right: -4,
-                          child: Container(
-                            padding: const EdgeInsets.all(3),
-                            decoration: const BoxDecoration(
-                              color: Colors.red,
-                              shape: BoxShape.circle,
-                            ),
-                            constraints: const BoxConstraints(
-                              minWidth: 12,
-                              minHeight: 12,
-                            ),
-                            child: Text(
-                              AlertService.instance.unreadCount.value
-                                  .clamp(0, 99)
-                                  .toString(),
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 9,
-                                fontWeight: FontWeight.bold,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
+                  // 未读告警 > 0 时把数字直接画进球体中心（吸附边缘时角标会被裁切，
+                  // 内嵌数字始终可见）。未读为 0 时显示原图标。
+                  // When there are unread alerts, render the count inside the ball
+                  // itself (a corner badge gets clipped when docked at the edge).
+                  child: _buildCenter(),
                 ),
               ),
             ),

--- a/lib/src/ui/inspector_panel.dart
+++ b/lib/src/ui/inspector_panel.dart
@@ -6,6 +6,7 @@ import 'database_viewer.dart';
 import 'memory_viewer.dart';
 import 'route_viewer.dart';
 import 'fps_viewer.dart';
+import 'alerts_viewer.dart';
 
 /// 检查器面板 / Inspector panel
 /// 包含网络、日志、数据库、内存、FPS、路由六个查看器 / Contains six viewers: network, logs, database, memory, FPS, routes
@@ -36,6 +37,7 @@ class _InspectorPanelState extends State<InspectorPanel>
     MemoryViewer(key: ValueKey('memory')),
     FpsViewer(key: ValueKey('fps')),
     RouteViewer(key: ValueKey('routes')),
+    AlertsViewer(key: ValueKey('alerts')),
   ];
 
   /// 标签页标题 / Tab titles
@@ -46,6 +48,7 @@ class _InspectorPanelState extends State<InspectorPanel>
     'Memory',
     'FPS',
     'Routes',
+    'Alerts',
   ];
 
   /// 标签页图标 / Tab icons
@@ -56,6 +59,7 @@ class _InspectorPanelState extends State<InspectorPanel>
     Icons.memory_rounded,
     Icons.speed_rounded,
     Icons.route_rounded,
+    Icons.notifications_active_rounded,
   ];
 
   @override

--- a/lib/src/ui/network_viewer.dart
+++ b/lib/src/ui/network_viewer.dart
@@ -177,6 +177,22 @@ class _NetworkViewerState extends State<NetworkViewer> {
                   onTap: () => _showInterceptorEditor(),
                   color: InspectorColors.accent,
                 ),
+              if (_selectedRequest != null)
+                InspectorIconButton(
+                  icon: Icons.terminal_rounded,
+                  tooltip: 'Copy as cURL',
+                  onTap: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    await ExportService.instance.copy(
+                      ExportService.instance.toCurl(_selectedRequest!),
+                    );
+                    if (mounted) {
+                      messenger.showSnackBar(
+                        const SnackBar(content: Text('Copied as cURL')),
+                      );
+                    }
+                  },
+                ),
               InspectorIconButton(
                 icon: Icons.content_copy_rounded,
                 tooltip: 'Copy as JSON',


### PR DESCRIPTION
## Summary
新增两项高频开发者工具能力，纯增量、无公共 API 破坏性变更、不触碰 native 代码。

### 1. 复制为 cURL
- `ExportService.toCurl(NetworkRequest)`：生成可直接在终端执行的 curl 命令（含 method、headers、body，自动转义引号/单引号）。
- 网络详情页工具栏新增 "Copy as cURL" 按钮（终端图标），点击即复制到剪贴板。

### 2. 告警规则 + 红点通知
- 新增 `AlertRule` 模型与 `AlertService`（单例）：内置默认规则（5xx 响应、慢请求 ≥1s、ERROR 及以上日志、内存 ≥200MB、FPS<50），环形缓冲存储最近 100 条告警事件，通过 `ValueNotifier<int> unreadCount` 暴露未读数。
- 在数据写入点接入检测：`InspectorService.addNetworkRequest` / `updateNetworkRequest` / `addLogEntry`、`MemoryInspectorService` 刷新、`FpsService` 刷新。
- 悬浮球按钮监听未读数，未读告警数直接画进球体中心（点击面板即清零）。
- 新增 `Alerts` 标签页（`alerts_viewer.dart`），展示告警列表与清空入口。

## Scope / 范围说明
- 本次仅覆盖 `feat/export-and-alerts` 中最高频的两项（cURL、告警）。网络列表批量选择、敏感字段隐藏开关按计划留作后续 PR，保持本次 review 范围聚焦。
- 按约定，http_interceptor.dart 拆分留到所有批次的最后。
- `flutter analyze` 无 issue，`flutter test` 152 用例全过（copy 的 binding 警告为既有测试环境限制，与本次改动无关）。

## Test plan
- [x] `flutter analyze` 无 issue
- [x] `flutter test` 152 个用例全过
