### PR TITLE
feat: network batch select and sensitive-header masking on export

### DIFF
--- a/lib/src/services/export_service.dart
+++ b/lib/src/services/export_service.dart
@@ -16,6 +16,17 @@ class ExportService {
   /// 单例实例 / Singleton instance
   static final ExportService instance = ExportService._();
 
+  /// 导出时需遮蔽的敏感请求头（不区分大小写）/ Sensitive headers to mask on export
+  static const Set<String> sensitiveHeaders = {
+    'authorization',
+    'cookie',
+    'set-cookie',
+    'proxy-authorization',
+    'x-auth-token',
+    'x-csrf-token',
+    'x-xsrf-token',
+  };
+
   // ==================== 导出方法 / Export methods ====================
 
   /// 日志 → JSON / Logs to JSON
@@ -43,24 +54,46 @@ class ExportService {
   }
 
   /// 网络请求 → JSON / Network to JSON
-  String netToJson(List<NetworkRequest> requests) => jsonEncode({
+  /// [maskSensitive] 为 true 时遮蔽敏感头。
+  String netToJson(
+    List<NetworkRequest> requests, {
+    bool maskSensitive = false,
+  }) => jsonEncode({
     'exportedAt': DateTime.now().toIso8601String(),
     'count': requests.length,
-    'requests': requests.map((e) => e.toJson()).toList(),
+    'requests': requests.map((e) => _maskedJson(e, maskSensitive)).toList(),
   });
+
+  /// 按 [maskSensitive] 决定是否遮蔽敏感头后再序列化 / Serialize with masking
+  Map<String, dynamic> _maskedJson(NetworkRequest e, bool maskSensitive) {
+    final json = e.toJson();
+    if (!maskSensitive || e.headers == null) return json;
+    final masked = <String, String>{};
+    for (final entry in e.headers!.entries) {
+      masked[entry.key] = sensitiveHeaders.contains(entry.key.toLowerCase())
+          ? '***'
+          : entry.value;
+    }
+    json['headers'] = masked;
+    return json;
+  }
 
   /// 网络请求 → 复制为 cURL 命令 / Network request → cURL command
   ///
   /// 生成可直接粘贴到终端执行的 curl 命令（含 method、headers、body）。
-  /// Produces a ready-to-run curl command (method, headers, body included).
-  String toCurl(NetworkRequest r) {
+  /// [maskSensitive] 为 true 时遮蔽 Authorization/Cookie 等敏感头。
+  /// Produces a ready-to-run curl command. When [maskSensitive] is true,
+  /// sensitive headers (Authorization/Cookie/...) are masked.
+  String toCurl(NetworkRequest r, {bool maskSensitive = false}) {
     final buf = StringBuffer()..write('curl -X ${r.method} ');
     // URL（含单引号时转义）/ URL (escape single quotes)
     final url = r.url.replaceAll("'", "%27");
     buf.writeln("'$url' \\");
     for (final e in (r.headers ?? {}).entries) {
+      final masked =
+          maskSensitive && sensitiveHeaders.contains(e.key.toLowerCase());
       final name = e.key.replaceAll('"', '\\"');
-      final value = e.value.replaceAll('"', '\\"');
+      final value = (masked ? '***' : e.value).replaceAll('"', '\\"');
       buf.writeln('  -H "$name: $value" \\');
     }
     if (r.body != null) {
@@ -99,11 +132,22 @@ class ExportService {
   /// 网络请求 → HAR 1.2 / Network to HAR 1.2
   ///
   /// 生成的 HAR 可直接导入 Chrome DevTools / Charles 等工具，极大提升与现有链路的互操作性。
-  /// The generated HAR can be imported into Chrome DevTools / Charles, improving interoperability.
-  String netToHar(List<NetworkRequest> requests) {
+  /// [maskSensitive] 为 true 时遮蔽敏感头。
+  /// The generated HAR can be imported into Chrome DevTools / Charles. When
+  /// [maskSensitive] is true, sensitive headers are masked.
+  String netToHar(List<NetworkRequest> requests, {bool maskSensitive = false}) {
     final entries = requests.map((r) {
       final reqHeaders = (r.headers ?? {}).entries
-          .map((e) => {'name': e.key, 'value': e.value})
+          .map(
+            (e) => {
+              'name': e.key,
+              'value':
+                  maskSensitive &&
+                      sensitiveHeaders.contains(e.key.toLowerCase())
+                  ? '***'
+                  : e.value,
+            },
+          )
           .toList();
       final startedMs = r.requestTime;
       final time = r.duration ?? 0;
@@ -170,11 +214,12 @@ class ExportService {
   Future<String> exportNetToFile(
     List<NetworkRequest> requests, {
     String format = 'json',
+    bool maskSensitive = false,
   }) {
     final content = switch (format) {
       'csv' => netToCsv(requests),
-      'har' => netToHar(requests),
-      _ => netToJson(requests),
+      'har' => netToHar(requests, maskSensitive: maskSensitive),
+      _ => netToJson(requests, maskSensitive: maskSensitive),
     };
     return writeToFile(content, 'zero_inspector_net.$format');
   }
@@ -186,8 +231,11 @@ class ExportService {
       copy(json ? logsToJson(logs) : logsToText(logs));
 
   /// 复制网络请求 / Copy network requests
-  Future<void> copyNet(List<NetworkRequest> requests) async =>
-      copy(netToJson(requests));
+  /// [maskSensitive] 为 true 时遮蔽敏感头。
+  Future<void> copyNet(
+    List<NetworkRequest> requests, {
+    bool maskSensitive = false,
+  }) async => copy(netToJson(requests, maskSensitive: maskSensitive));
 
   /// 复制任意内容到剪贴板 / Copy any content to clipboard
   Future<void> copy(String content) async {

--- a/lib/src/services/inspector_service.dart
+++ b/lib/src/services/inspector_service.dart
@@ -234,6 +234,12 @@ class InspectorService extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 按 id 删除单条网络请求（批量删除用）/ Remove a single request by id
+  void removeNetworkRequest(String id) {
+    _networkRequests.removeWhere((r) => r.id == id);
+    notifyListeners();
+  }
+
   /// 清空日志记录 / Clear log records
   void clearLogs() {
     _logEntries.clear();

--- a/lib/src/ui/network_viewer.dart
+++ b/lib/src/ui/network_viewer.dart
@@ -30,6 +30,17 @@ class _NetworkViewerState extends State<NetworkViewer> {
   RequestInterceptorRule? _editingRule;
   bool _showInterceptorPanel = false;
 
+  /// 导出时是否遮蔽敏感请求头（Authorization/Cookie 等）。默认开启。
+  /// Whether to mask sensitive headers (Authorization/Cookie/...) on export.
+  /// Enabled by default for safety.
+  bool _maskSensitive = true;
+
+  /// 批量选择模式 / Batch selection mode
+  bool _selectionMode = false;
+
+  /// 已选中的请求 id 集合 / Selected request ids
+  final Set<String> _selectedIds = {};
+
   /// 从实时列表中解析当前选中的请求；找不到（已被淘汰）时返回 null。
   /// Resolves the selected request from the live list; null if evicted.
   NetworkRequest? get _selectedRequest {
@@ -165,6 +176,29 @@ class _NetworkViewerState extends State<NetworkViewer> {
                 ),
               ),
               const Spacer(),
+              // 列表页：敏感字段遮蔽开关 + 批量选择入口
+              // List page: sensitive-field mask toggle + batch-select entry
+              if (_selectedRequest == null) ...[
+                InspectorIconButton(
+                  icon: _maskSensitive
+                      ? Icons.visibility_off_rounded
+                      : Icons.visibility_rounded,
+                  tooltip: _maskSensitive
+                      ? 'Sensitive hidden'
+                      : 'Sensitive visible',
+                  color: _maskSensitive ? InspectorColors.error : null,
+                  onTap: () => setState(() => _maskSensitive = !_maskSensitive),
+                ),
+                InspectorIconButton(
+                  icon: Icons.checklist_rounded,
+                  tooltip: _selectionMode ? 'Exit selection' : 'Select',
+                  color: _selectionMode ? InspectorColors.accent : null,
+                  onTap: () => setState(() {
+                    _selectionMode = !_selectionMode;
+                    if (!_selectionMode) _selectedIds.clear();
+                  }),
+                ),
+              ],
               // 拦截总开关 / Interceptor master switch（仅列表页显示）
               if (_selectedRequest == null)
                 _buildInterceptorSwitch(interceptorOn),
@@ -184,11 +218,20 @@ class _NetworkViewerState extends State<NetworkViewer> {
                   onTap: () async {
                     final messenger = ScaffoldMessenger.of(context);
                     await ExportService.instance.copy(
-                      ExportService.instance.toCurl(_selectedRequest!),
+                      ExportService.instance.toCurl(
+                        _selectedRequest!,
+                        maskSensitive: _maskSensitive,
+                      ),
                     );
                     if (mounted) {
                       messenger.showSnackBar(
-                        const SnackBar(content: Text('Copied as cURL')),
+                        SnackBar(
+                          content: Text(
+                            _maskSensitive
+                                ? 'Copied as cURL (sensitive hidden)'
+                                : 'Copied as cURL',
+                          ),
+                        ),
                       );
                     }
                   },
@@ -200,22 +243,38 @@ class _NetworkViewerState extends State<NetworkViewer> {
                   final requests = InspectorService.instance.networkRequests;
                   if (requests.isEmpty) return;
                   final messenger = ScaffoldMessenger.of(context);
-                  await ExportService.instance.copyNet(requests);
+                  await ExportService.instance.copyNet(
+                    requests,
+                    maskSensitive: _maskSensitive,
+                  );
                   if (mounted) {
                     messenger.showSnackBar(
                       SnackBar(
                         content: Text(
-                          'Copied ${requests.length} requests as JSON',
+                          'Copied ${requests.length} requests as JSON'
+                          '${_maskSensitive ? ' (sensitive hidden)' : ''}',
                         ),
                       ),
                     );
                   }
                 },
               ),
+              if (_selectionMode)
+                InspectorIconButton(
+                  icon: Icons.copy_all_rounded,
+                  tooltip: 'Copy selected as cURL',
+                  onTap: () => _copySelectedCurl(context),
+                ),
               InspectorIconButton(
                 icon: Icons.delete_outline_rounded,
-                tooltip: 'Clear',
-                onTap: () => InspectorService.instance.clearNetworkRequests(),
+                tooltip: _selectionMode ? 'Delete selected' : 'Clear all',
+                onTap: () {
+                  if (_selectionMode) {
+                    _deleteSelected();
+                  } else {
+                    InspectorService.instance.clearNetworkRequests();
+                  }
+                },
               ),
             ],
           ),
@@ -309,10 +368,87 @@ class _NetworkViewerState extends State<NetworkViewer> {
       );
     }
 
-    return ListView.builder(
-      itemCount: requests.length,
-      itemBuilder: (context, index) => _buildRequestItem(requests[index]),
+    return Column(
+      children: [
+        if (_selectionMode) _buildBatchBar(requests),
+        Expanded(
+          child: ListView.builder(
+            itemCount: requests.length,
+            itemBuilder: (context, index) => _buildRequestItem(requests[index]),
+          ),
+        ),
+      ],
     );
+  }
+
+  /// 批量操作条 / Batch action bar
+  Widget _buildBatchBar(List<NetworkRequest> requests) {
+    final allSelected =
+        requests.isNotEmpty &&
+        requests.every((r) => _selectedIds.contains(r.id));
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: InspectorColors.primary.withValues(alpha: 0.12),
+        border: Border(bottom: BorderSide(color: InspectorColors.border)),
+      ),
+      child: Row(
+        children: [
+          TextButton(
+            onPressed: () => setState(() {
+              if (allSelected) {
+                _selectedIds.clear();
+              } else {
+                _selectedIds.addAll(requests.map((r) => r.id));
+              }
+            }),
+            child: Text(
+              allSelected ? 'Deselect all' : 'Select all',
+              style: TextStyle(color: InspectorColors.accent, fontSize: 12),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '${_selectedIds.length} selected',
+            style: TextStyle(
+              color: InspectorColors.textSecondary,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _copySelectedCurl(BuildContext context) {
+    final messenger = ScaffoldMessenger.of(context);
+    final list = InspectorService.instance.networkRequests;
+    final selected = list.where((r) => _selectedIds.contains(r.id)).toList();
+    if (selected.isEmpty) return;
+    final curl = selected
+        .map(
+          (r) =>
+              ExportService.instance.toCurl(r, maskSensitive: _maskSensitive),
+        )
+        .join('\n\n');
+    ExportService.instance.copy(curl);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Copied ${selected.length} cURL'
+          '${_maskSensitive ? ' (sensitive hidden)' : ''}',
+        ),
+      ),
+    );
+  }
+
+  void _deleteSelected() {
+    final list = InspectorService.instance.networkRequests;
+    final toRemove = list.where((r) => _selectedIds.contains(r.id)).toList();
+    for (final r in toRemove) {
+      InspectorService.instance.removeNetworkRequest(r.id);
+    }
+    setState(() => _selectedIds.clear());
   }
 
   Widget _buildRequestItem(NetworkRequest request) {
@@ -322,11 +458,22 @@ class _NetworkViewerState extends State<NetworkViewer> {
           request.method,
         ) !=
         null;
+    final selected = _selectedIds.contains(request.id);
 
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => setState(() => _selectedRequestId = request.id),
+        onTap: () => setState(() {
+          if (_selectionMode) {
+            if (selected) {
+              _selectedIds.remove(request.id);
+            } else {
+              _selectedIds.add(request.id);
+            }
+          } else {
+            _selectedRequestId = request.id;
+          }
+        }),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(
@@ -343,6 +490,19 @@ class _NetworkViewerState extends State<NetworkViewer> {
             children: [
               Row(
                 children: [
+                  if (_selectionMode)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: Icon(
+                        selected
+                            ? Icons.check_circle_rounded
+                            : Icons.radio_button_unchecked_rounded,
+                        size: 16,
+                        color: selected
+                            ? InspectorColors.accent
+                            : InspectorColors.textHint,
+                      ),
+                    ),
                   Container(
                     padding: const EdgeInsets.symmetric(
                       horizontal: 7,


### PR DESCRIPTION
## Summary
为网络查看器新增批量操作与导出脱敏两项能力。无公共 API 破坏性变更，不触碰 native 代码。

### 1. 批量选择 + 批量操作
- 列表页工具栏新增「Select」按钮进入批量模式；列表项前显示勾选图标，点击切换选中（不再打开详情）。
- 批量模式下顶部出现操作条：全选 / 取消全选、已选计数。
- 工具栏在批量模式下提供「复制选中为 cURL」（Copy selected as cURL）与「删除选中」（Delete selected）。
- `InspectorService` 新增 `removeNetworkRequest(id)` 支持按 id 删除。

### 2. 敏感字段遮蔽（默认开启）
- `ExportService` 新增敏感头集合（authorization / cookie / set-cookie / proxy-authorization / x-auth-token / x-csrf-token / x-xsrf-token）。
- `toCurl` / `netToJson` / `netToHar` / `copyNet` / `exportNetToFile` 增加 `maskSensitive` 参数，开启时敏感头值替换为 `***`。
- 列表页工具栏新增眼睛图标开关（默认开启），控制 cURL / JSON 导出是否遮蔽；详情页「Copy as cURL」同样受影响，snackbar 提示是否隐藏了敏感字段。

## Scope / 范围说明
- 属于 `feat/export-and-alerts` 主题收尾批次，纯增量。
- 按约定，`http_interceptor.dart` 拆分仍留到所有批次的最后。
- `flutter analyze` 无 issue，`flutter test` 152 用例全过（copy 的 binding 警告为既有测试环境限制，与本次改动无关）。

## Test plan
- [x] `flutter analyze` 无 issue
- [x] `flutter test` 152 个用例全过
