### PR TITLE
fix: re-run PR title check on synchronize and skip bot commits

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -6,13 +6,7 @@ on:
       - opened
       - edited
       - reopened
-      # NOTE: `synchronize` is intentionally omitted. The `dart-format-fix`
-      # workflow pushes a bot commit on every sync, which would re-trigger this
-      # title check and make the PR appear stuck on the title status. The PR
-      # title cannot change on `synchronize` anyway, so re-checking is pointless.
-      # 注意:故意不含 `synchronize`。dart-format-fix 会在每次同步时推送 bot 提交,
-      # 重新触发本标题检查,导致 PR 标题状态卡住。而同步时 PR 标题不可能变化,
-      # 重复校验毫无意义。
+      - synchronize
 
 permissions:
   pull-requests: read
@@ -21,6 +15,14 @@ jobs:
   check-title:
     name: Check PR Title (Conventional Commits)
     runs-on: ubuntu-latest
+    # Re-run on `synchronize` so the title check is reported again on the new
+    # head commit (otherwise it shows as pending/yellow after a human re-push).
+    # Skip the bot's own sync commit from `dart-format-fix` to avoid a loop and
+    # to keep the status green: the title never changes on a format-only push.
+    # 恢复 `synchronize`:人类再次 push 时,标题检查会在新 head commit 上重跑,
+    # 否则该 check 在新 commit 上缺条目、显示为黄色 pending。同时用 actor 条件
+    # 跳过 dart-format-fix 的 bot 同步提交,避免循环触发且标题本来不会变。
+    if: github.actor != 'github-actions[bot]'
     steps:
       - name: Validate PR title format
         uses: amannn/action-semantic-pull-request@v6


### PR DESCRIPTION
## Summary

修复 PR 标题检查（Check PR Title）在分支保护下会卡在黄色 pending 的问题。

**问题根因**
- 之前 `pr-title-check.yml` 故意省略了 `synchronize` 触发器。
- 当 PR 已通过标题检查（绿色）但**尚未合并**，作者再次 push 新 commit 时，`ci.yml` 会在新 head commit 上重跑，而标题检查因不监听 `synchronize` 不会重跑。
- 结果：该 required status check 在新 commit 上缺少条目，分支保护将其视为 pending，PR 状态卡在黄色，即使标题本身合规也无法合并。

**修复方式**
- 恢复 `synchronize` 触发器，使标题检查在新 head commit 上重新上报状态。
- 在 job 级增加 `if: github.actor != 'github-actions[bot]'`，跳过 `dart-format-fix` 工作流自动推送的 bot 格式提交，避免循环触发、且格式提交不会改变 PR 标题。

## Changed Files

- `.github/workflows/pr-title-check.yml`
  - 在 `pull_request_target.types` 中加回 `synchronize`
  - job 增加 `if: github.actor != 'github-actions[bot]'`
  - 更新注释说明

## Test Plan

- [ ] 开一个 PR（标题合规）→ 标题检查绿色
- [ ] 不合并，再次 push 一个 commit → 标题检查在新 commit 上重跑并保持绿色，不再黄色 pending
- [ ] 触发 `dart-format-fix` 自动格式化 bot 提交 → 标题检查不被循环触发（bot 提交被 `if` 跳过）
- [ ] PR 标题不合规时（如 `update something`）→ 标题检查仍为红色失败
