### PR TITLE
chore: release v1.3.1 - alert throttling and docs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.3.1
+
+> **🛡️ 告警防风暴 / Alert storm protection：** 本版本为告警系统新增同源节流，避免持续超阈值（内存/FPS 轮询）或突发 5xx/慢请求淹没告警缓冲与未读红点。
+> This release adds per-source throttling to the alert system so sustained threshold breaches (memory/FPS polling) or bursts of 5xx/slow requests no longer flood the alert buffer and unread badge.
+
+本版本在告警触发路径上新增节流逻辑，并补充了对应的单元测试。公共 API 不变。
+This release adds throttling to the alert firing path and ships unit tests for it. Public API unchanged.
+
+**新增 / Added:**
+
+- 告警同源节流 / Per-source alert throttling
+  - `AlertService._fire` 新增按 `(source, message)` 的 1 秒滑动窗口节流：同一来源在冷却期内重复触发被去重，避免告警风暴
+  - `AlertService._fire` now applies a 1-second sliding-window throttle keyed on `(source, message)`: repeated firings from the same source within the cooldown are deduplicated to prevent alert storms
+  - 节流键使用记录类型 `(String, String)`，避免 URL 含 `|` 分隔符时的键冲突
+  - The throttle key uses a `(String, String)` record, avoiding key collisions when a URL contains the `|` separator
+  - 持续状态仍会周期提醒：冷却结束后（≥1 秒）同源再次出现仍会正常触发，保证持续问题不会被永久压制
+  - Sustained conditions still re-alert periodically: after the cooldown elapses (≥1s) a same-source occurrence fires again, so persistent issues are never permanently suppressed
+  - `clearAll()` 同时清理节流表，与告警缓冲保持一致的生命周期
+  - `clearAll()` also clears the throttle table, keeping its lifecycle consistent with the alert buffer
+- 单元测试 / Unit tests
+  - 新增 `test/alert_service_test.dart`，覆盖节流去重、防风暴、规则评估（网络/日志/内存/FPS）、`clearAll` 生命周期与默认规则
+  - Added `test/alert_service_test.dart` covering throttle deduplication, storm prevention, rule evaluation (network/log/memory/FPS), `clearAll` lifecycle, and default rules
+
 ## 1.3.0
 
 > **🚀 新功能 / New features：** 本版本为网络面板新增批量操作与敏感字段遮蔽导出，并引入告警系统与悬浮球未读红点；同时对 HTTP 拦截器做了纯内部重构（行为不变）。

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 Upgrade recommended:** v1.3.0 adds network batch operations, sensitive-field masking on export, one-click cURL copy, an alert system with an unread badge, and refactors the HTTP interceptor internally (no behavior change). All users are advised to upgrade to `^1.3.0`.
+> **🔔 Upgrade recommended:** v1.3.1 adds per-source alert throttling (prevents alert storms from sustained threshold breaches or request bursts) on top of v1.3.0's network batch operations, sensitive-field masking on export, one-click cURL copy, and the alert system with an unread badge. All users are advised to upgrade to `^1.3.1`.
 
 🌐 **[Official Website](https://www.zerolabsco.com/)**
 
@@ -26,7 +26,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 - **Memory Monitor**: Real-time memory monitoring with trend chart, Dart Heap details, Native memory breakdown (Android PSS / iOS physicalFootprint), memory leak detection, image cache monitoring, and app storage statistics. Master switch to avoid performance overhead.
 - **FPS Monitor**: Real-time FPS measurement, frame duration stats, jank detection, and FPS trend chart (30-second window). Master switch to avoid performance overhead.
 - **Route Tracker**: Monitor navigation history and current route information.
-- **Alert System**: Define alert rules on network requests, logs, memory, and FPS to surface problems proactively. The floating button shows an unread-count badge (cleared when the panel is opened), and an Alerts tab lists triggered alerts.
+- **Alert System**: Define alert rules on network requests, logs, memory, and FPS to surface problems proactively. The floating button shows an unread-count badge (cleared when the panel is opened), and an Alerts tab lists triggered alerts. Per-source throttling (1-second sliding window keyed on source + message) suppresses duplicate alerts during sustained breaches or request bursts, while periodic re-alerts keep persistent issues visible.
 - **Floating Button**: Accessible floating inspector button with breathing animation, rendered via root `Overlay` so it stays independent of any page's widget tree. Drag and release to auto-dock and tuck into the nearest screen edge (only a small peek visible); tap the peek to smoothly pull it out, then tap again to open the panel. This avoids conflicts with system back-gesture edges.
 - **Modern UI**: Beautiful dark theme with gradient design, customizable colors via centralized theme configuration.
 - **Cross-platform**: Works on Android and iOS.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -541,7 +541,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/lib/src/services/alert_service.dart
+++ b/lib/src/services/alert_service.dart
@@ -38,10 +38,11 @@ class AlertService {
 
   /// 各来源上次触发时间（毫秒时间戳），用于节流同源重复告警
   /// Last fire time per (source, message) key (ms timestamp), used to
-  /// throttle duplicate alerts. Keyed on source+message so a single
-  /// request that hits multiple rules (e.g. 5xx + slow) still surfaces
-  /// each distinct alert.
-  final Map<String, int> _lastFiredAt = <String, int>{};
+  /// throttle duplicate alerts. Keyed on a (source, message) record so a
+  /// single request that hits multiple rules (e.g. 5xx + slow) still
+  /// surfaces each distinct alert, and there is no string-collision risk
+  /// when a URL contains the `|` separator.
+  final Map<(String, String), int> _lastFiredAt = <(String, String), int>{};
 
   /// 未读告警数（供红点）/ Unread alert count (for red dot)
   final ValueNotifier<int> unreadCount = ValueNotifier<int>(0);
@@ -132,7 +133,7 @@ class AlertService {
   /// [_perSourceCooldownMs] are throttled to avoid alert storms.
   void _fire(String source, String message) {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final key = '$source|$message';
+    final key = (source, message);
     final last = _lastFiredAt[key];
     if (last != null && now - last < _perSourceCooldownMs) {
       return;

--- a/lib/src/services/alert_service.dart
+++ b/lib/src/services/alert_service.dart
@@ -20,11 +20,28 @@ class AlertService {
   /// 告警事件环形缓冲上限 / Alert event ring buffer cap
   static const int _maxEvents = 100;
 
+  /// 同一来源的告警最小触发间隔（毫秒）/ Min interval between alerts from the same source (ms)
+  ///
+  /// 防止同一来源（如持续高位内存、慢请求）高频触发导致告警风暴。
+  /// 设为 1 秒：内存/FPS 定时器周期 500ms 下同一来源至少 1 秒 1 条；
+  /// 突发 5xx/慢请求在同一秒内只记 1 条，1 秒后再次出现仍会触发。
+  /// Prevents alert storms from high-frequency checks on a single source
+  /// (e.g. sustained high memory, a slow endpoint). 1s: at most one event
+  /// per source per second; a new occurrence after the cooldown still fires.
+  static const int _perSourceCooldownMs = 1000;
+
   /// 已启用的规则（默认内置）/ Enabled rules (defaults built-in)
   final List<AlertRule> _rules = List.of(AlertRule.defaults);
 
   /// 告警事件缓冲 / Alert event buffer
   final ListQueue<AlertEvent> _events = ListQueue();
+
+  /// 各来源上次触发时间（毫秒时间戳），用于节流同源重复告警
+  /// Last fire time per (source, message) key (ms timestamp), used to
+  /// throttle duplicate alerts. Keyed on source+message so a single
+  /// request that hits multiple rules (e.g. 5xx + slow) still surfaces
+  /// each distinct alert.
+  final Map<String, int> _lastFiredAt = <String, int>{};
 
   /// 未读告警数（供红点）/ Unread alert count (for red dot)
   final ValueNotifier<int> unreadCount = ValueNotifier<int>(0);
@@ -56,6 +73,7 @@ class AlertService {
   /// 清空全部告警 / Clear all alerts
   void clearAll() {
     _events.clear();
+    _lastFiredAt.clear();
     unreadCount.value = 0;
   }
 
@@ -107,7 +125,20 @@ class AlertService {
   }
 
   /// 触发一条告警：入队并累加未读 / Fire an alert: enqueue and bump unread
+  ///
+  /// 同 (source, message) 在 [_perSourceCooldownMs] 毫秒内重复触发会被节流，
+  /// 避免高频检查（如 500ms 内存/FPS 轮询、慢请求循环）淹没告警缓冲。
+  /// Repeated firings for the same (source, message) within
+  /// [_perSourceCooldownMs] are throttled to avoid alert storms.
   void _fire(String source, String message) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final key = '$source|$message';
+    final last = _lastFiredAt[key];
+    if (last != null && now - last < _perSourceCooldownMs) {
+      return;
+    }
+    _lastFiredAt[key] = now;
+
     _events.addFirst(AlertEvent(source: source, message: message));
     while (_events.length > _maxEvents) {
       _events.removeLast();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zero_inspector_kit
 description: A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/zero-labsco/zero_inspector_kit
 repository: https://github.com/zero-labsco/zero_inspector_kit
 

--- a/test/alert_service_test.dart
+++ b/test/alert_service_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zero_inspector_kit/src/models/log_entry.dart';
+import 'package:zero_inspector_kit/src/models/network_request.dart';
+import 'package:zero_inspector_kit/src/services/alert_service.dart';
+
+/// AlertService 单元测试 / AlertService unit tests
+///
+/// 重点覆盖 v1.3.0 新增的告警系统：节流、防风暴、规则评估、生命周期。
+/// 主要聚焦在「告警风暴」防御：高频检查下同一来源不应淹没缓冲。
+/// Focus on the v1.3.0 alert system: throttling, anti-storm, rule
+/// evaluation, lifecycle. Especially storm prevention: high-frequency
+/// checks on the same source must not flood the buffer.
+void main() {
+  late AlertService alerts;
+
+  setUp(() {
+    // 告警服务是单例；测试间显式清空避免相互污染
+    // AlertService is a singleton; explicitly clear between tests.
+    alerts = AlertService.instance;
+    alerts.clearAll();
+  });
+
+  tearDown(() {
+    alerts.clearAll();
+  });
+
+  group('Lifecycle / 生命周期', () {
+    test('default rules are present / 默认规则已注册', () {
+      expect(alerts.rules, isNotEmpty);
+      expect(
+        alerts.rules.any((r) => r.kind.toString().contains('httpStatus')),
+        isTrue,
+      );
+      expect(
+        alerts.rules.any((r) => r.kind.toString().contains('memoryMb')),
+        isTrue,
+      );
+      expect(
+        alerts.rules.any((r) => r.kind.toString().contains('fpsLow')),
+        isTrue,
+      );
+    });
+
+    test('initial unread count is 0 / 初始未读数为 0', () {
+      expect(alerts.unreadCount.value, equals(0));
+      expect(alerts.events, isEmpty);
+    });
+
+    test('clearAll resets events and unread / clearAll 重置事件与未读', () {
+      alerts.checkMemory(999);
+      expect(alerts.unreadCount.value, greaterThan(0));
+      alerts.clearAll();
+      expect(alerts.events, isEmpty);
+      expect(alerts.unreadCount.value, equals(0));
+    });
+  });
+
+  group('Storm prevention / 防风暴节流', () {
+    test(
+      'memory above threshold fires only once per cooldown window '
+      'under rapid checks / 高频检测下内存告警每秒最多 1 条',
+      () {
+        for (var i = 0; i < 1000; i++) {
+          alerts.checkMemory(500);
+        }
+        // 1000 次调用落在同一毫秒内 → 只产生 1 条告警
+        expect(alerts.events.length, equals(1));
+        expect(alerts.unreadCount.value, equals(1));
+        expect(alerts.events.first.source, equals('memory'));
+      },
+    );
+
+    test(
+      'low FPS fires only once per cooldown window under rapid checks '
+      '/ 高频检测下 FPS 告警每秒最多 1 条',
+      () {
+        for (var i = 0; i < 500; i++) {
+          alerts.checkFps(20);
+        }
+        expect(alerts.events.length, equals(1));
+        expect(alerts.unreadCount.value, equals(1));
+        expect(alerts.events.first.source, equals('fps'));
+      },
+    );
+
+    test(
+      'same slow URL does not flood the buffer / 同一慢请求 URL 不刷屏',
+      () {
+        final req = NetworkRequest(
+          id: 'r1',
+          method: 'GET',
+          url: 'https://api.example.com/slow',
+          requestTime: 0,
+          responseTime: 5000,
+          statusCode: 200,
+          duration: 5000,
+        );
+        for (var i = 0; i < 200; i++) {
+          alerts.checkNetwork(req);
+        }
+        // 同 URL + 持续超阈值：被节流到 1 条
+        expect(alerts.events.length, equals(1));
+        expect(alerts.unreadCount.value, equals(1));
+      },
+    );
+
+    test(
+      'different sources fire independently / 不同来源互不影响',
+      () {
+        alerts.checkMemory(500);
+        alerts.checkFps(20);
+        alerts.checkNetwork(
+          NetworkRequest(
+            id: 'r1',
+            method: 'GET',
+            url: 'https://api.example.com/a',
+            requestTime: 0,
+            statusCode: 500,
+            duration: 0,
+          ),
+        );
+        expect(alerts.events.length, equals(3));
+        expect(alerts.unreadCount.value, equals(3));
+      },
+    );
+
+    test(
+      'after cooldown elapses, same source can fire again '
+      '/ 冷却结束后同来源可再次触发',
+      () {
+        alerts.checkMemory(500);
+        expect(alerts.events.length, equals(1));
+        // 模拟冷却结束：手动复用 _fire 的内部节流表无法直接测试，
+        // 但可通过 clearAll 验证节流状态被清理后能再次触发。
+        alerts.clearAll();
+        alerts.checkMemory(500);
+        expect(alerts.events.length, equals(1));
+        expect(alerts.unreadCount.value, equals(1));
+      },
+    );
+
+    test(
+      'single request hitting both 5xx and slow rules fires both alerts '
+      '/ 单次请求同时命中 5xx 与慢请求规则时两条告警都触发',
+      () {
+        final req = NetworkRequest(
+          id: 'r1',
+          method: 'GET',
+          url: 'https://api.example.com/both',
+          requestTime: 0,
+          responseTime: 5000,
+          statusCode: 500,
+          duration: 5000,
+        );
+        // 同 source 但不同 message 应互不影响
+        alerts.checkNetwork(req);
+        expect(alerts.events.length, equals(2));
+        expect(
+          alerts.events.any((e) => e.message.contains('HTTP 500')),
+          isTrue,
+        );
+        expect(
+          alerts.events.any((e) => e.message.contains('Slow')),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('Rule evaluation / 规则评估', () {
+    test(
+      'requests below thresholds do not fire / 未越过阈值的请求不触发',
+      () {
+        alerts.checkNetwork(
+          NetworkRequest(
+            id: 'r1',
+            method: 'GET',
+            url: 'https://api.example.com/ok',
+            requestTime: 0,
+            statusCode: 200,
+            duration: 50,
+          ),
+        );
+        expect(alerts.events, isEmpty);
+        expect(alerts.unreadCount.value, equals(0));
+      },
+    );
+
+    test(
+      'non-ERROR log level does not fire / 非 ERROR 日志不触发',
+      () {
+        final entry = LogEntry(
+          id: 'l1',
+          level: LogLevel.info,
+          message: 'hello',
+          timestamp: DateTime.now(),
+        );
+        alerts.checkLog(entry);
+        expect(alerts.events, isEmpty);
+      },
+    );
+
+    test(
+      'ERROR log fires / ERROR 日志触发告警',
+      () {
+        final entry = LogEntry(
+          id: 'l1',
+          level: LogLevel.error,
+          message: 'boom',
+          timestamp: DateTime.now(),
+          tag: 'auth',
+        );
+        alerts.checkLog(entry);
+        expect(alerts.events.length, equals(1));
+        expect(alerts.events.first.source, equals('auth'));
+      },
+    );
+  });
+}

--- a/test/alert_service_test.dart
+++ b/test/alert_service_test.dart
@@ -56,164 +56,131 @@ void main() {
   });
 
   group('Storm prevention / 防风暴节流', () {
-    test(
-      'memory above threshold fires only once per cooldown window '
-      'under rapid checks / 高频检测下内存告警每秒最多 1 条',
-      () {
-        for (var i = 0; i < 1000; i++) {
-          alerts.checkMemory(500);
-        }
-        // 1000 次调用落在同一毫秒内 → 只产生 1 条告警
-        expect(alerts.events.length, equals(1));
-        expect(alerts.unreadCount.value, equals(1));
-        expect(alerts.events.first.source, equals('memory'));
-      },
-    );
-
-    test(
-      'low FPS fires only once per cooldown window under rapid checks '
-      '/ 高频检测下 FPS 告警每秒最多 1 条',
-      () {
-        for (var i = 0; i < 500; i++) {
-          alerts.checkFps(20);
-        }
-        expect(alerts.events.length, equals(1));
-        expect(alerts.unreadCount.value, equals(1));
-        expect(alerts.events.first.source, equals('fps'));
-      },
-    );
-
-    test(
-      'same slow URL does not flood the buffer / 同一慢请求 URL 不刷屏',
-      () {
-        final req = NetworkRequest(
-          id: 'r1',
-          method: 'GET',
-          url: 'https://api.example.com/slow',
-          requestTime: 0,
-          responseTime: 5000,
-          statusCode: 200,
-          duration: 5000,
-        );
-        for (var i = 0; i < 200; i++) {
-          alerts.checkNetwork(req);
-        }
-        // 同 URL + 持续超阈值：被节流到 1 条
-        expect(alerts.events.length, equals(1));
-        expect(alerts.unreadCount.value, equals(1));
-      },
-    );
-
-    test(
-      'different sources fire independently / 不同来源互不影响',
-      () {
+    test('memory above threshold fires only once per cooldown window '
+        'under rapid checks / 高频检测下内存告警每秒最多 1 条', () {
+      for (var i = 0; i < 1000; i++) {
         alerts.checkMemory(500);
+      }
+      // 1000 次调用落在同一毫秒内 → 只产生 1 条告警
+      expect(alerts.events.length, equals(1));
+      expect(alerts.unreadCount.value, equals(1));
+      expect(alerts.events.first.source, equals('memory'));
+    });
+
+    test('low FPS fires only once per cooldown window under rapid checks '
+        '/ 高频检测下 FPS 告警每秒最多 1 条', () {
+      for (var i = 0; i < 500; i++) {
         alerts.checkFps(20);
-        alerts.checkNetwork(
-          NetworkRequest(
-            id: 'r1',
-            method: 'GET',
-            url: 'https://api.example.com/a',
-            requestTime: 0,
-            statusCode: 500,
-            duration: 0,
-          ),
-        );
-        expect(alerts.events.length, equals(3));
-        expect(alerts.unreadCount.value, equals(3));
-      },
-    );
+      }
+      expect(alerts.events.length, equals(1));
+      expect(alerts.unreadCount.value, equals(1));
+      expect(alerts.events.first.source, equals('fps'));
+    });
 
-    test(
-      'after cooldown elapses, same source can fire again '
-      '/ 冷却结束后同来源可再次触发',
-      () {
-        alerts.checkMemory(500);
-        expect(alerts.events.length, equals(1));
-        // 模拟冷却结束：手动复用 _fire 的内部节流表无法直接测试，
-        // 但可通过 clearAll 验证节流状态被清理后能再次触发。
-        alerts.clearAll();
-        alerts.checkMemory(500);
-        expect(alerts.events.length, equals(1));
-        expect(alerts.unreadCount.value, equals(1));
-      },
-    );
+    test('same slow URL does not flood the buffer / 同一慢请求 URL 不刷屏', () {
+      final req = NetworkRequest(
+        id: 'r1',
+        method: 'GET',
+        url: 'https://api.example.com/slow',
+        requestTime: 0,
+        responseTime: 5000,
+        statusCode: 200,
+        duration: 5000,
+      );
+      for (var i = 0; i < 200; i++) {
+        alerts.checkNetwork(req);
+      }
+      // 同 URL + 持续超阈值：被节流到 1 条
+      expect(alerts.events.length, equals(1));
+      expect(alerts.unreadCount.value, equals(1));
+    });
 
-    test(
-      'single request hitting both 5xx and slow rules fires both alerts '
-      '/ 单次请求同时命中 5xx 与慢请求规则时两条告警都触发',
-      () {
-        final req = NetworkRequest(
+    test('different sources fire independently / 不同来源互不影响', () {
+      alerts.checkMemory(500);
+      alerts.checkFps(20);
+      alerts.checkNetwork(
+        NetworkRequest(
           id: 'r1',
           method: 'GET',
-          url: 'https://api.example.com/both',
+          url: 'https://api.example.com/a',
           requestTime: 0,
-          responseTime: 5000,
           statusCode: 500,
-          duration: 5000,
-        );
-        // 同 source 但不同 message 应互不影响
-        alerts.checkNetwork(req);
-        expect(alerts.events.length, equals(2));
-        expect(
-          alerts.events.any((e) => e.message.contains('HTTP 500')),
-          isTrue,
-        );
-        expect(
-          alerts.events.any((e) => e.message.contains('Slow')),
-          isTrue,
-        );
-      },
-    );
+          duration: 0,
+        ),
+      );
+      expect(alerts.events.length, equals(3));
+      expect(alerts.unreadCount.value, equals(3));
+    });
+
+    test('after cooldown elapses, same source can fire again '
+        '/ 冷却结束后同来源可再次触发', () {
+      alerts.checkMemory(500);
+      expect(alerts.events.length, equals(1));
+      // 模拟冷却结束：手动复用 _fire 的内部节流表无法直接测试，
+      // 但可通过 clearAll 验证节流状态被清理后能再次触发。
+      alerts.clearAll();
+      alerts.checkMemory(500);
+      expect(alerts.events.length, equals(1));
+      expect(alerts.unreadCount.value, equals(1));
+    });
+
+    test('single request hitting both 5xx and slow rules fires both alerts '
+        '/ 单次请求同时命中 5xx 与慢请求规则时两条告警都触发', () {
+      final req = NetworkRequest(
+        id: 'r1',
+        method: 'GET',
+        url: 'https://api.example.com/both',
+        requestTime: 0,
+        responseTime: 5000,
+        statusCode: 500,
+        duration: 5000,
+      );
+      // 同 source 但不同 message 应互不影响
+      alerts.checkNetwork(req);
+      expect(alerts.events.length, equals(2));
+      expect(alerts.events.any((e) => e.message.contains('HTTP 500')), isTrue);
+      expect(alerts.events.any((e) => e.message.contains('Slow')), isTrue);
+    });
   });
 
   group('Rule evaluation / 规则评估', () {
-    test(
-      'requests below thresholds do not fire / 未越过阈值的请求不触发',
-      () {
-        alerts.checkNetwork(
-          NetworkRequest(
-            id: 'r1',
-            method: 'GET',
-            url: 'https://api.example.com/ok',
-            requestTime: 0,
-            statusCode: 200,
-            duration: 50,
-          ),
-        );
-        expect(alerts.events, isEmpty);
-        expect(alerts.unreadCount.value, equals(0));
-      },
-    );
+    test('requests below thresholds do not fire / 未越过阈值的请求不触发', () {
+      alerts.checkNetwork(
+        NetworkRequest(
+          id: 'r1',
+          method: 'GET',
+          url: 'https://api.example.com/ok',
+          requestTime: 0,
+          statusCode: 200,
+          duration: 50,
+        ),
+      );
+      expect(alerts.events, isEmpty);
+      expect(alerts.unreadCount.value, equals(0));
+    });
 
-    test(
-      'non-ERROR log level does not fire / 非 ERROR 日志不触发',
-      () {
-        final entry = LogEntry(
-          id: 'l1',
-          level: LogLevel.info,
-          message: 'hello',
-          timestamp: DateTime.now(),
-        );
-        alerts.checkLog(entry);
-        expect(alerts.events, isEmpty);
-      },
-    );
+    test('non-ERROR log level does not fire / 非 ERROR 日志不触发', () {
+      final entry = LogEntry(
+        id: 'l1',
+        level: LogLevel.info,
+        message: 'hello',
+        timestamp: DateTime.now(),
+      );
+      alerts.checkLog(entry);
+      expect(alerts.events, isEmpty);
+    });
 
-    test(
-      'ERROR log fires / ERROR 日志触发告警',
-      () {
-        final entry = LogEntry(
-          id: 'l1',
-          level: LogLevel.error,
-          message: 'boom',
-          timestamp: DateTime.now(),
-          tag: 'auth',
-        );
-        alerts.checkLog(entry);
-        expect(alerts.events.length, equals(1));
-        expect(alerts.events.first.source, equals('auth'));
-      },
-    );
+    test('ERROR log fires / ERROR 日志触发告警', () {
+      final entry = LogEntry(
+        id: 'l1',
+        level: LogLevel.error,
+        message: 'boom',
+        timestamp: DateTime.now(),
+        tag: 'auth',
+      );
+      alerts.checkLog(entry);
+      expect(alerts.events.length, equals(1));
+      expect(alerts.events.first.source, equals('auth'));
+    });
   });
 }


### PR DESCRIPTION
## Summary

This PR releases **v1.3.1** by merging the `release/v1.3.1` snapshot branch into `main`.

- **Per-source alert throttling** (`AlertService`): added a 1-second sliding-window throttle keyed on `(source, message)` so sustained threshold breaches (memory/FPS polling) or bursts of 5xx/slow requests no longer flood the alert buffer and unread badge. After the cooldown elapses (≥1s), a same-source occurrence still fires, so persistent issues are never permanently suppressed. `clearAll()` also clears the throttle table.
- **Key-collision hardening**: the throttle key uses a `(String, String)` record instead of a `|`-joined string, avoiding collisions when a URL contains `|`.
- **Tests**: added `test/alert_service_test.dart` (12 cases) covering throttle deduplication, storm prevention, rule evaluation (network/log/memory/FPS), and lifecycle.
- **Docs**: updated `README.md` (upgrade banner + Alert System description) and `CHANGELOG.md` (1.3.1 entry).
- Includes the previous publish fixes: `.codebuddy/` untracked and `.pubignore` excludes `docs/` + internal files, resolving the `dart pub publish` validation warnings.

Public API unchanged.

## Changed Files

- `lib/src/services/alert_service.dart` — throttle logic + record key
- `test/alert_service_test.dart` — new unit tests
- `pubspec.yaml` — version 1.3.0 → 1.3.1
- `CHANGELOG.md` — 1.3.1 entry
- `README.md` — alert throttle docs

## Test Plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 164 tests pass (incl. 12 new alert tests)
- [x] `dart format .` — clean
- [x] `v1.3.1` tag pushed (triggers `pub-publish.yml`)

## Note

`release/v1.3.1` is an inert snapshot branch; this PR brings its content into `main`. The `v1.3.1` tag (not the branch) drives publishing.
