### PR TITLE
docs: add pub.dev link to README and sync docs to v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.0
+  zero_inspector_kit: ^1.3.1
 ```
 
 ### GitHub
 
-Alternatively, you can install from GitHub (replace `1.3.0` with the version you need):
+Alternatively, you can install from GitHub (replace `1.3.1` with the version you need):
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.3.0
+      ref: v1.3.1
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 
 🌐 **[Official Website](https://www.zerolabsco.com/)**
 
+📦 **[View on pub.dev](https://pub.dev/packages/zero_inspector_kit)**
+
 🔗 **[View on GitHub](https://github.com/zero-labsco/zero_inspector_kit)**
 
 ## Features

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,7 @@
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 推荐升级：** v1.3.0 新增网络批量操作、导出敏感字段遮蔽、一键复制 cURL、告警系统（悬浮球未读红点），并对 HTTP 拦截器做了纯内部重构（行为不变）。建议所有用户升级到 `^1.3.0`。
+> **🔔 推荐升级：** v1.3.1 在 v1.3.0 的网络批量操作、导出敏感字段遮蔽、一键复制 cURL、告警系统（悬浮球未读红点）基础上，新增告警同源节流（避免持续超阈值或请求突发的告警风暴）。建议所有用户升级到 `^1.3.1`。
 
 🌐 **[官方网站](https://www.zerolabsco.com/)**
 
@@ -28,7 +28,7 @@
 - **内存监控**: 实时内存监控，包含趋势图、Dart Heap 详情、Native 内存分项（Android PSS / iOS physicalFootprint）、内存泄漏检测、图片缓存监控和应用存储统计。提供总开关避免性能开销。
 - **FPS 监控**: 实时帧率测量、帧耗时统计、掉帧检测、FPS 趋势折线图（30 秒窗口）。提供总开关避免性能开销。
 - **路由追踪器**: 监控导航历史和当前路由信息。
-- **告警系统**: 可针对网络请求、日志、内存、FPS 定义告警规则，主动暴露问题。悬浮球显示未读告警数红点（打开面板即清零），Alerts 标签页列出已触发的告警。
+- **告警系统**: 可针对网络请求、日志、内存、FPS 定义告警规则，主动暴露问题。悬浮球显示未读告警数红点（打开面板即清零），Alerts 标签页列出已触发的告警。同源节流（基于 source + message 的 1 秒滑动窗口）会在持续超阈值或请求突发时抑制重复告警，同时周期性的重新触发保证持续问题始终可见。
 - **悬浮按钮**: 带呼吸动画的可访问悬浮检查按钮，通过根 `Overlay` 渲染，独立于任意页面的 widget 树。拖动松手后自动吸附并"收入"最近的屏幕边缘（仅露出小部分）；点击露出部分会平滑拉出到完整可见，再次点击才打开面板。此设计避免了与系统边缘返回手势的冲突。
 - **跨平台**: 支持 Android 和 iOS 平台。
 
@@ -40,19 +40,19 @@
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.0
+  zero_inspector_kit: ^1.3.1
 ```
 
 ### GitHub
 
-或者，你也可以从 GitHub 安装（将 `1.3.0` 替换为你需要的版本号）：
+或者，你也可以从 GitHub 安装（将 `1.3.1` 替换为你需要的版本号）：
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.3.0
+      ref: v1.3.1
 ```
 
 ## 使用方法
@@ -276,7 +276,6 @@ DatabaseRegistry.instance.registerProvider(SqliteDatabaseProvider());
 myBloc.trackMemoryLeak(tag: 'HomePage_myBloc');
 
 // 或使用顶层函数
-// Or use top-level function
 trackMemoryLeak(myBloc, tag: 'HomePage_myBloc');
 
 // 取消追踪

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,6 +15,8 @@
 
 🌐 **[官方网站](https://www.zerolabsco.com/)**
 
+📦 **[在 pub.dev 查看](https://pub.dev/packages/zero_inspector_kit)**
+
 🔗 **[查看 GitHub 仓库](https://github.com/zero-labsco/zero_inspector_kit)**
 
 ## 功能特性

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,7 +8,7 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.2.0
+  zero_inspector_kit: ^1.3.1
 ```
 
 Then run:


### PR DESCRIPTION
## Summary / 摘要
- Added a pub.dev text link to the link block of both `README.md` and `README_zh.md`, placed between the Official Website and GitHub entries.
- 在 `README.md` 与 `README_zh.md` 的链接区块中，于「官方网站」与「GitHub」之间新增了 pub.dev 文字链接。
- Synced README install examples and the docs site to the published v1.3.1 (version pins `^1.3.0`/`v1.3.0` → `^1.3.1`/`v1.3.1`, docs site `^1.2.0` → `^1.3.1`).
- 将 README 安装示例与文档站同步到已发布的 v1.3.1（版本号 `^1.3.0`/`v1.3.0` → `^1.3.1`/`v1.3.1`，文档站点 `^1.2.0` → `^1.3.1`）。
- Aligned the Chinese README upgrade notice and Alert System description with the English version (including per-source 1s throttle).
- 将中文 README 的升级提示与告警系统描述与英文对齐（含同源 1 秒节流说明）。
- Removed a leftover English comment in the Chinese README.
- 删除了中文 README 中残留的英文注释。

## Commits / 提交列表
- `a7097c7` docs: add pub.dev link to README
- `ac9f5de` docs: add pub.dev link to Chinese README
- `d0bfc42` docs: sync README and docs to v1.3.1 and add pub.dev link

## Changed Files / 改动文件
- `README.md` — pub.dev link; install version pins → `^1.3.1` / `v1.3.1`.
- `README_zh.md` — pub.dev link; upgrade notice + Alert System throttle note; version pins → `^1.3.1` / `v1.3.1`; removed stray English comment.
- `docs/Installation.md` — install version pin → `^1.3.1`.

## Test Plan / 测试计划
- Docs-only change; no code affected.
- 仅文档改动，不涉及代码。
- CI required checks (`Analyze & Test`, `Pana Score Check`, `Check PR Title`) are unaffected.
- CI 必过的三项检查不受影响。

## Note / 说明
- "Available since v1.3.0" notes in `docs/Alerts.md` / `docs/Network-Inspector.md` were intentionally left unchanged — they mark when each feature was first introduced.
- `docs/Alerts.md` / `docs/Network-Inspector.md` 中的 "Available since v1.3.0" 标注为功能首次引入版本，故未改动。
