### PR TITLE
docs: sync wiki to v1.3.1 (Alerts, sensitive masking, cURL, version bump)

### DIFF
--- a/wiki/Alerts.md
+++ b/wiki/Alerts.md
@@ -1,0 +1,45 @@
+# Alerts / 告警系统
+
+## Overview / 概述
+
+> **Available since v1.3.0**
+>
+> **v1.3.0 起可用**
+
+The alert system lets you define rules that proactively surface problems across network requests, logs, memory, and FPS — without manually scanning the panels.
+
+告警系统允许你定义规则，主动暴露网络请求、日志、内存、FPS 方面的问题，无需手动逐个面板排查。
+
+## How It Works / 工作原理
+
+- Rules are evaluated by `AlertService` whenever a relevant event occurs / 每当相关事件发生时，`AlertService` 会评估规则
+- Matched rules produce alerts, and the unread count is exposed via a `ValueNotifier<int>` / 命中的规则会生成告警，未读数通过 `ValueNotifier<int>` 暴露
+- The floating button shows an unread-count badge; opening the panel clears it / 悬浮球显示未读数量角标，打开面板即清零
+- An **Alerts** tab in the inspector panel lists all triggered alerts / 检查器面板的 **Alerts** 标签页列出所有已触发的告警
+
+## Rule Types / 规则类型
+
+| Type | Trigger / 触发条件 | Example / 示例 |
+|------|-------------------|----------------|
+| **Network** | Response status code / 响应状态码 | Alert when status ≥ 400 / 状态码 ≥ 400 时告警 |
+| **Log** | Log level or message / 日志级别或内容 | Alert on error logs / 出现 error 日志时告警 |
+| **Memory** | Dart heap / Native memory threshold / 内存阈值 | Alert when Dart heap > 100 MB / Dart 堆 > 100 MB 时告警 |
+| **FPS** | Frame rate / 帧率 | Alert when FPS < 50 / FPS < 50 时告警 |
+
+## UI Features / UI 功能
+
+### Floating Button Badge / 悬浮球角标
+
+- A red badge shows the current unread alert count (clamped 0–99) / 红色角标显示当前未读告警数（0–99）
+- The number is drawn inside the button so it is never clipped at screen edges / 数字直接绘制在按钮内部，吸附屏幕边缘时不会被裁切
+- Opening the inspector panel clears the unread count / 打开检查器面板即清零未读数
+
+### Alerts Tab / Alerts 标签页
+
+- Lists triggered alerts with type, condition, and timestamp / 列出已触发告警的类型、条件与时间
+- Tap an alert to jump to the related panel (network / log / memory / FPS) / 点击告警可跳转到相关面板（网络 / 日志 / 内存 / FPS）
+
+## Notes / 备注
+
+- Alerts are evaluated in-process and shown in the developer console only; they do not send data off-device / 告警仅在本机开发者控制台内评估与展示，不会将数据发送到设备外
+- The alert system is tree-shaken out in release builds, like the rest of the inspector / 与检查器其余部分一样，告警系统在 release 构建中被 tree-shake 移除

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -16,6 +16,8 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 | **Memory Viewer** | Trend chart, Dart Heap, Native memory, leak detection / 内存趋势图、Dart Heap、Native 内存、泄漏检测 |
 | **FPS Monitor** | Real-time FPS, jank rate, trend chart / 实时 FPS、卡顿率、趋势图 |
 | **Fuzzy Search** | Search in all viewers / 三大查看器模糊搜索 |
+| **Alerts** | Rule-based proactive alerts for network/log/memory/FPS / 基于规则的主动告警（网络/日志/内存/FPS） |
+| **Sensitive Masking & cURL** | Mask sensitive fields and copy requests as cURL / 敏感字段遮蔽与复制为 cURL |
 | **Cross-platform** | Android, iOS / 跨平台支持 |
 
 ## 📚 Table of Contents / 目录
@@ -31,6 +33,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 | [Route Tracker](Route-Tracker) | Route tracking / 路由追踪 |
 | [Memory Viewer](Memory-Viewer) | Memory monitoring & leak detection / 内存监控与泄漏检测 |
 | [FPS Viewer](FPS-Viewer) | FPS monitoring & jank detection / FPS 监控与卡顿检测 |
+| [Alerts](Alerts) | Rule-based proactive alerting / 基于规则的主动告警 |
 | [Configuration](Configuration) | Configuration options / 配置说明 |
 | [Custom Database Provider](Custom-Database-Provider) | Extend database support / 自定义数据库提供者 |
 | [FAQ](FAQ) | Frequently asked questions / 常见问题 |

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -8,7 +8,7 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.2.0
+  zero_inspector_kit: ^1.3.1
 ```
 
 Then run:

--- a/wiki/Network-Inspector.md
+++ b/wiki/Network-Inspector.md
@@ -47,6 +47,51 @@ The inspector uses Flutter's `HttpOverrides` to intercept all HTTP traffic at th
 - Fuzzy search by URL or method / 按 URL 或方法模糊搜索
 - Search bar hidden in detail view / 详情视图隐藏搜索栏
 
+### Batch Operations / 批量操作
+
+> **Available since v1.3.0**
+>
+> **v1.3.0 起可用**
+
+The request list supports a selection mode for operating on multiple requests at once.
+
+请求列表支持选择模式，可一次性操作多条请求。
+
+- Tap the **selection icon** in the toolbar to enter selection mode / 点击工具栏的**选择图标**进入选择模式
+- Check/uncheck items; a top batch bar shows **Select all** / **Cancel** / 勾选/取消勾选；顶部批量条提供**全选** / **取消**
+- **Batch "Copy as cURL"**: copies all selected requests as cURL commands / **批量「Copy as cURL」**：将所有选中请求复制为 cURL 命令
+- **Batch delete**: removes selected requests from the list / **批量删除**：从列表中移除选中请求
+
+### Export & Sensitive-field Masking / 导出与敏感字段遮蔽
+
+> **Available since v1.3.0**
+>
+> **v1.3.0 起可用**
+
+The toolbar includes an **eye toggle** that controls whether sensitive headers are masked on export.
+
+工具栏包含**眼睛开关**，控制导出时是否遮蔽敏感请求头。
+
+- **Default: off (fully visible)** — cURL / JSON / HAR reflect the real request verbatim / **默认关闭（完整可见）**：cURL / JSON / HAR 原样反映真实请求
+- **On**: `toCurl` / `netToJson` / `netToHar` / `copyNet` / `exportNetToFile` mask these headers / **开启后**：以下请求头被遮蔽：
+  - `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Auth-Token`, `X-CSRF-Token`, `X-XSRF-Token`
+- The detail page "Copy as cURL" / "Copy as JSON" follow the same toggle / 详情页「Copy as cURL」「Copy as JSON」跟随同一开关
+- When masking is active, the snackbar notes **(sensitive hidden)** / 遮蔽开启时，snackbar 提示 **(sensitive hidden)**
+
+> Tip: keep masking **on** before pasting cURL/JSON into terminals, chat, or issue trackers to avoid leaking credentials.
+>
+> 提示：将 cURL/JSON 粘贴到终端、聊天或 issue 前，建议开启遮蔽，避免凭据泄露。
+
+### Copy as cURL / 复制为 cURL
+
+> **Available since v1.3.0**
+>
+> **v1.3.0 起可用**
+
+From the request detail view, tap **Copy as cURL** to copy the request as a ready-to-run cURL command (method, URL, headers, body). Respects the sensitive-field masking toggle above.
+
+在请求详情页点击 **Copy as cURL**，即可将请求复制为可直接运行的 cURL 命令（方法、URL、请求头、请求体），并遵循上方的敏感字段遮蔽开关。
+
 ## Status Code Colors / 状态码颜色
 
 | Range | Color | Description |

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -13,6 +13,7 @@
 - 🧭 [Route Tracker](Route-Tracker)
 - 📊 [Memory Viewer](Memory-Viewer)
 - 🎯 [FPS Viewer](FPS-Viewer)
+- 🔔 [Alerts](Alerts)
 
 ## 🛠 Advanced
 

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>Zero Inspector Kit · Docs</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <meta name="description" content="Zero Inspector Kit — A powerful Flutter plugin for in-app developer console.">
+  <link rel="icon" href="https://www.zerolabsco.com/favicon.ico">
+  <!-- Docsify 主题（可换成 buble / dark / dolphin） -->
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  <style>
+    :root {
+      --theme-color: #e5484d;
+    }
+    .markdown-section {
+      max-width: 880px;
+    }
+    .app-footer {
+      text-align: center;
+      padding: 1.2rem 1rem;
+      color: #8a8a8a;
+      font-size: 0.82rem;
+      border-top: 1px solid #eee;
+    }
+    .app-footer a { color: #8a8a8a; text-decoration: none; }
+    .app-footer a:hover { color: var(--theme-color); }
+    .app-footer .sep { margin: 0 .5rem; }
+  </style>
+</head>
+<body>
+  <div id="app">Loading documentation…</div>
+
+  <!-- 固定页脚（对应原 wiki 的 _Footer.md） -->
+  <footer class="app-footer">
+    📖 Zero Inspector Kit
+    <span class="sep">|</span>
+    <a href="https://github.com/zero-labsco/zero_inspector_kit" target="_blank" rel="noopener">GitHub</a>
+    <span class="sep">|</span>
+    <a href="https://www.zerolabsco.com/" target="_blank" rel="noopener">Website</a>
+    <span class="sep">|</span>
+    GPL-3.0 License
+  </footer>
+
+  <script>
+    window.$docsify = {
+      name: 'Zero Inspector Kit',
+      repo: 'https://github.com/zero-labsco/zero_inspector_kit',
+      homepage: 'Home.md',
+      loadSidebar: '_Sidebar.md',   // 复用 wiki 的 _Sidebar.md，无需改名
+      subMaxLevel: 2,
+      maxLevel: 4,
+      auto2top: true,
+      search: {
+        maxAge: 86400000,
+        paths: 'auto',
+        placeholder: 'Search docs…',
+        noData: 'No results found.',
+        depth: 4
+      },
+      copyCode: {
+        buttonText: 'Copy',
+        errorText: 'Error',
+        successText: 'Copied'
+      },
+      notFoundPage: true
+    };
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify-copy-code@4/dist/docsify-copy-code.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-yaml.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-dart.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary (EN)
Sync the legacy `wiki/` directory with the current `docs/` (GitHub Pages) content, which had fallen behind after the v1.3.0 / v1.3.1 releases.

Changes:
- Add `wiki/Alerts.md` — rule-based proactive alerting (network/log/memory/FPS), floating-button badge, and Alerts tab.
- `wiki/Home.md` — add **Alerts** and **Sensitive Masking & cURL** to the feature table and the navigation table.
- `wiki/Installation.md` — bump pub dependency to `^1.3.1`.
- `wiki/Network-Inspector.md` — add **Batch Operations**, **Export & Sensitive-field Masking**, and **Copy as cURL** sections (v1.3.0).
- `wiki/_Sidebar.md` — add the **Alerts** entry.

Note: `wiki/**` is intentionally not in `ci.yml` `paths-ignore`, so this docs-only PR still triggers the workflow but matches no `code` path → `code=false` → Analyze & Test and Pana Score Check skip green.

## 摘要 (ZH)
将落后的旧版 `wiki/` 目录与当前 `docs/`（GitHub Pages）内容同步，后者在 v1.3.0 / v1.3.1 发布后已更新。

改动：
- 新增 `wiki/Alerts.md` — 基于规则的主动告警（网络/日志/内存/FPS）、悬浮球角标与 Alerts 标签页。
- `wiki/Home.md` — 特性表与目录表补充 **Alerts** 与 **Sensitive Masking & cURL**。
- `wiki/Installation.md` — pub 依赖版本更新为 `^1.3.1`。
- `wiki/Network-Inspector.md` — 补充 **批量操作**、**导出与敏感字段遮蔽**、**复制为 cURL** 三段（v1.3.0）。
- `wiki/_Sidebar.md` — 补充 **Alerts** 条目。

说明：`wiki/**` 刻意不在 `ci.yml` 的 `paths-ignore` 中，因此纯文档 PR 仍会触发 workflow，但匹配不到任何 `code` 路径 → `code=false` → Analyze & Test 与 Pana Score Check 绿色跳过。
