### PR TITLE
Ci/fix wiki trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,21 @@ on:
     # 注意：README*.md / CHANGELOG.md / docs/** 等用户态文档「不」在此忽略——否则纯文档 PR
     # 会让 ci.yml 整条 workflow 被跳过，导致分支保护的 required checks 永远不出现、PR 无法合并。
     # 纯文档改动仍会触发 ci.yml，但被 path-filter 判定为 code=false，重 job 绿色跳过。
-    # NOTE: user-facing docs (README*.md / CHANGELOG.md / docs/**) are intentionally NOT ignored.
-    # Ignoring them would skip the entire ci.yml workflow for docs-only PRs, leaving the
-    # branch-protection required checks permanently pending and blocking merge.
-    # Docs-only PRs still trigger ci.yml but the heavy jobs skip green via path-filter (code=false).
+    # NOTE: user-facing docs (README*.md / CHANGELOG.md / docs/** / wiki/**, plus any other
+    # `**.md`) are intentionally NOT ignored. Ignoring them would skip the entire ci.yml
+    # workflow for docs-only PRs, leaving the branch-protection required checks permanently
+    # pending and blocking merge. Docs-only PRs still trigger ci.yml but the heavy jobs
+    # skip green via path-filter (code=false). The same applies to CONTRIBUTING.md / TODO.md
+    # and any other markdown that may be the sole change in a PR.
     paths-ignore:
       # Convention/agent docs (AGENTS.md, .codebuddy/**) are intentionally NOT ignored
       # so docs-only PRs still run CI and satisfy branch protection's required checks.
-      - 'CONTRIBUTING.md'    # Contributing guide (doesn't affect the package)
-      - 'TODO.md'            # Todo file
+      # 注意：以下文档类项刻意不在此忽略（否则纯文档 PR 会让整条 workflow 跳过、required checks 黄色卡死）：
+      #   README*.md / CHANGELOG.md / docs/** / wiki/** / CONTRIBUTING.md / TODO.md / 任意其他 **.md
+      # 它们不是 code 路径，但作为文档 PR 要让 workflow 触发（code=false → 绿色跳过）。
+      # NOTE: the following doc-like paths are intentionally NOT ignored (same reason as above):
+      #   README*.md / CHANGELOG.md / docs/** / wiki/** / CONTRIBUTING.md / TODO.md / any other **.md
+      # They are not in the code path-filter, so docs-only PRs still trigger ci.yml but skip heavy jobs green.
       # 注意：wiki/** 刻意不在此忽略。wiki 是遗留目录但仍有更新 PR；忽略它会导致纯 wiki 改动跳过整
       # 条 workflow，使 required checks 永远不出现、PR 无法合并。纯 wiki 改动会触发 workflow，但
       # path-filter 中无 wiki 路径 → code=false → 两个重 job 绿色跳过。
@@ -49,13 +55,16 @@ on:
     branches: [main, 'v*.*.*']
     # Apply same ignore rules for PRs
     # 对 PR 应用相同的忽略规则
-    # 注意：README*.md / CHANGELOG.md / docs/** 不在忽略列表（见 push 段说明），确保纯文档 PR 也能触发 ci.yml。
-    # NOTE: README*.md / CHANGELOG.md / docs/** are NOT ignored (see push block) so docs-only PRs still trigger ci.yml.
+    # 注意：README*.md / CHANGELOG.md / docs/** / wiki/** / CONTRIBUTING.md / TODO.md / 任意其他 **.md
+    # 不在忽略列表（见 push 段说明），确保纯文档 PR 也能触发 ci.yml，required checks 不会黄色卡死。
+    # NOTE: README*.md / CHANGELOG.md / docs/** / wiki/** / CONTRIBUTING.md / TODO.md / any other **.md
+    # are NOT ignored (see push block) so docs-only PRs still trigger ci.yml.
     paths-ignore:
       # Convention/agent docs (AGENTS.md, .codebuddy/**) are intentionally NOT ignored
       # so docs-only PRs still run CI and satisfy branch protection's required checks.
-      - 'CONTRIBUTING.md'    # Contributing guide (doesn't affect the package)
-      - 'TODO.md'            # Todo file
+      # 注意：以下文档类项刻意不在此忽略（原因见 push 段）：README*.md / CHANGELOG.md / docs/** /
+      # wiki/** / CONTRIBUTING.md / TODO.md / 任意其他 **.md —— 它们不是 code 路径，但会让 workflow
+      # 触发（code=false → 绿色跳过），避免纯文档 PR 的 required checks 黄色卡死。
       # 注意：wiki/** 刻意不在此忽略。wiki 是遗留目录但仍有更新 PR；忽略它会导致纯 wiki 改动跳过整
       # 条 workflow，使 required checks 永远不出现、PR 无法合并。纯 wiki 改动会触发 workflow，但
       # path-filter 中无 wiki 路径 → code=false → 两个重 job 绿色跳过。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,12 @@ on:
       # so docs-only PRs still run CI and satisfy branch protection's required checks.
       - 'CONTRIBUTING.md'    # Contributing guide (doesn't affect the package)
       - 'TODO.md'            # Todo file
-      - 'wiki/**'            # Wiki documentation directory (legacy, migrated to docs/)
+      # 注意：wiki/** 刻意不在此忽略。wiki 是遗留目录但仍有更新 PR；忽略它会导致纯 wiki 改动跳过整
+      # 条 workflow，使 required checks 永远不出现、PR 无法合并。纯 wiki 改动会触发 workflow，但
+      # path-filter 中无 wiki 路径 → code=false → 两个重 job 绿色跳过。
+      # NOTE: wiki/** is intentionally NOT ignored. It is a legacy directory but still receives update PRs;
+      # ignoring it would skip the entire workflow for wiki-only changes, leaving required checks pending.
+      # Wiki-only PRs still trigger the workflow, but path-filter has no wiki paths → code=false → heavy jobs skip green.
       # 精细化忽略 GitHub 配置，但保留 workflows/ 目录的 CI 触发（Dependabot 改 action 版本需要跑 CI）
       # Finer-grained GitHub ignores — workflows MUST trigger CI (Dependabot action updates need CI)
       - '.github/ISSUE_TEMPLATE/**'     # Issue/PR templates
@@ -51,7 +56,12 @@ on:
       # so docs-only PRs still run CI and satisfy branch protection's required checks.
       - 'CONTRIBUTING.md'    # Contributing guide (doesn't affect the package)
       - 'TODO.md'            # Todo file
-      - 'wiki/**'            # Wiki documentation directory (legacy, migrated to docs/)
+      # 注意：wiki/** 刻意不在此忽略。wiki 是遗留目录但仍有更新 PR；忽略它会导致纯 wiki 改动跳过整
+      # 条 workflow，使 required checks 永远不出现、PR 无法合并。纯 wiki 改动会触发 workflow，但
+      # path-filter 中无 wiki 路径 → code=false → 两个重 job 绿色跳过。
+      # NOTE: wiki/** is intentionally NOT ignored. It is a legacy directory but still receives update PRs;
+      # ignoring it would skip the entire workflow for wiki-only changes, leaving required checks pending.
+      # Wiki-only PRs still trigger the workflow, but path-filter has no wiki paths → code=false → heavy jobs skip green.
       # 精细化忽略 GitHub 配置，但保留 workflows/ 目录的 CI 触发
       # Finer-grained GitHub ignores — workflows MUST trigger CI
       - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
## Summary (EN)
The `ci.yml` workflow currently lists `wiki/**` in `paths-ignore`, which causes any PR that only touches `wiki/` to skip the entire CI workflow. As a result, the three branch-protection required checks stay in the "Expected — Waiting for status to be reported" state and the PR cannot be merged.

This change removes `wiki/**` from both `push` and `pull_request` `paths-ignore` blocks. Wiki-only PRs will now trigger `ci.yml`; since `wiki/**` is not in the `code` path-filter list, `Analyze & Test` and `Pana Score Check` will still skip green (no pana run), and the required checks can report success.

## 摘要 (ZH)
`ci.yml` 当前在 `paths-ignore` 中列了 `wiki/**`，导致只改动 `wiki/` 的 PR 会跳过整条 CI workflow，三个分支保护必需检查一直卡在 "Expected — Waiting for status to be reported"，PR 无法合并。

本次改动将 `wiki/**` 从 `push` 与 `pull_request` 的 `paths-ignore` 中移除。纯 wiki PR 会触发 `ci.yml`；又因为 `wiki/**` 不在 `code` 路径过滤列表中，`Analyze & Test` 与 `Pana Score Check` 仍会绿色跳过（不跑 pana），从而满足 required checks。

## What changed
- `.github/workflows/ci.yml`:
  - Removed `- 'wiki/**'` from both `push.paths-ignore` and `pull_request.paths-ignore`.
  - Added bilingual comments explaining why `wiki/**` must remain un-ignored.
