### PR TITLE
fix: compute network request duration only when response arrives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ migrate_working_dir/
 # IDE project data (includes Improvement-Plan.md, must not be committed)
 .codebuddy/
 
+# Trae IDE share/export packages (HTML export zips, not project code)
+.trae-html-share-packages/
+
 # IntelliJ related
 *.iml
 *.ipr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,44 @@ This file defines the architecture, coding conventions, and required workflows f
 - PR titles MUST follow Conventional Commits, enforced by `pr-title-check.yml` (`amannn/action-semantic-pull-request@v6`).
 - Required checks before merge: `Analyze & Test`, `Pana Score Check`, `Check PR Title (Conventional Commits)`.
 
+### Pull request body template / PR 正文模板
+
+AI coding agents (CodeBuddy, Trae, Cursor, Claude Code, GitHub Copilot, Codex, etc.) and contributors SHOULD follow the body template below when opening PRs. Keep the `###` section structure; fill in real content. Use English as the primary language and Chinese as the secondary language (EN-primary, ZH-secondary) for each section. Brand the assistant with **Zero Buddy** (two words, NOT "ZeroBuddy") at the end.
+
+AI 协作工具（CodeBuddy、Trae、Cursor、Claude Code、GitHub Copilot、Codex 等）与贡献者开 PR 时应遵循以下正文模板。保留 `###` 章节结构并填入真实内容。每个章节采用英文为主、中文为辅（EN-primary, ZH-secondary）。文末以 **Zero Buddy**（两个单词，不要写成 "ZeroBuddy"）署名。
+
+```markdown
+### Summary / 摘要
+
+<one-line plain-English summary> + <对应中文一句话摘要>
+
+### Changes / 变更
+
+- <change bullet, EN> / <中文说明>
+- <change bullet, EN> / <中文说明>
+
+### Context / 背景
+
+<why this change is needed, EN> / <改动背景的中文说明>
+
+### Checklist / 检查项
+
+- [ ] Title follows Conventional Commits / 标题符合约定式提交
+- [ ] CI checks pass after merge / 合入后 CI 通过
+
+## Test plan
+
+- [ ] <how to verify, EN> / <验证方式>
+
+🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
+```
+
+Notes / 说明:
+- The PR **title** stays English-only and MUST follow Conventional Commits (enforced by `pr-title-check.yml`). Bilingual content goes in the body only.
+  PR **标题**仅用英文，且必须符合约定式提交（`pr-title-check.yml` 强制校验）。双语内容只放在正文。
+- For Dependabot PRs, do NOT author the body manually — `dependabot-pr-bilingual.yml` auto-appends the bilingual summary (see CI section).
+  Dependabot 的 PR 不要手动写正文，由 `dependabot-pr-bilingual.yml` 自动追加双语摘要（见 CI 段）。
+
 ### CI
 - `ci.yml`: `actions/checkout@v7`, `subosito/flutter-action@v2`, `actions/cache@v5` (pub cache keyed on `pubspec.lock` plus `example/pubspec.lock`); runs `flutter analyze`, `flutter test`, and `pana` score check.
 - `stale.yml`: `actions/stale@v11` marks stale issues/PRs.
@@ -66,7 +104,8 @@ This file defines the architecture, coding conventions, and required workflows f
    - `flutter pub publish --dry-run` — confirm the package scores well on `pana` and no files are unintentionally excluded.
 4. Commit on a branch, open PR, merge to `main` after the 3 required checks pass.
 5. Tag (drives publishing): `git tag vX.Y.Z <commit> && git push origin vX.Y.Z`. The `vX.Y.Z` tag — NOT a branch — triggers `pub-publish.yml`. Never name a branch `vX.Y.Z`; it collides with the tag refspec and breaks `git push`.
-6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots.
+6. Archive branch (optional, for release snapshots): create `release-vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release-vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots. The remote `v*` archive branches were renamed to `release-v*` to prevent tag/branch refspec ambiguity.
+   - 远程 `v*` 归档分支已重命名为 `release-*` 以避免 tag 与分支的 refspec 歧义。
 7. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
    - Note: `k-paxian` internally uses older actions that emit Node 20 deprecation warnings. This is accepted (B1 decision); functionality is unaffected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.3.2
+
+> **🐛 缺陷修复 / Bug fix：** 修复网络请求耗时（duration）在响应尚未到达时即被错误计算的问题。
+> This release fixes an issue where network request duration was calculated prematurely, before the response had actually arrived.
+
+本版本修复了 HTTP 拦截器在捕获请求体（body）阶段误将请求标记为已完成、导致耗时计算错误的问题，并补充了对应的单元测试。公共 API 不变。
+This release fixes a bug where the HTTP interceptor mistakenly marked a request as complete (and computed its duration) during request-body capture, and adds unit tests for it. Public API unchanged.
+
+**修复 / Fixed:**
+
+- 网络请求耗时计算时机 / Network request duration timing
+  - `InspectorService.updateNetworkRequest` 现在仅在提供 `statusCode`（即响应到达）时才设置 `responseTime` 与 `duration`；仅更新请求体（body，例如 HTTP 拦截器在 `close()` 中捕获请求体）时保留原值，不再过早标记请求已完成
+  - `InspectorService.updateNetworkRequest` now only sets `responseTime` and `duration` when `statusCode` is provided (response arrival). Updating only the request body (e.g. HTTP interceptor capturing the body in `close()`) keeps them unset, so requests are no longer prematurely marked complete
+  - 修复后：先捕获请求体、后收到响应的请求，其 `duration` 反映真实的响应耗时而非请求体捕获时刻
+  - After the fix: a request whose body is captured first and response arrives later reports `duration` for the real response time, not the body-capture moment
+- 单元测试 / Unit tests
+  - `test/models_test.dart` 新增 `InspectorService.updateNetworkRequest responseTime` 测试组，覆盖：仅更新 body 不设置 `responseTime`、提供 `statusCode` 设置、先 body 后响应的时序
+  - `test/models_test.dart` adds the `InspectorService.updateNetworkRequest responseTime` group covering: body-only update leaves `responseTime` unset, `statusCode` sets it, and the body-then-response sequence
+
 ## 1.3.1
 
 > **🛡️ 告警防风暴 / Alert storm protection：** 本版本为告警系统新增同源节流，避免持续超阈值（内存/FPS 轮询）或突发 5xx/慢请求淹没告警缓冲与未读红点。

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 Upgrade recommended:** v1.3.1 adds per-source alert throttling (prevents alert storms from sustained threshold breaches or request bursts) on top of v1.3.0's network batch operations, sensitive-field masking on export, one-click cURL copy, and the alert system with an unread badge. All users are advised to upgrade to `^1.3.1`.
+> **🔔 Upgrade recommended:** v1.3.2 fixes network request duration being calculated prematurely (before the response arrives) on top of v1.3.1's per-source alert throttling and v1.3.0's network batch operations, sensitive-field masking on export, one-click cURL copy, and the alert system with an unread badge. All users are advised to upgrade to `^1.3.2`.
 
 🌐 **[Official Website](https://www.zerolabsco.com/)**
 
@@ -41,19 +41,19 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.1
+  zero_inspector_kit: ^1.3.2
 ```
 
 ### GitHub
 
-Alternatively, you can install from GitHub (replace `1.3.1` with the version you need):
+Alternatively, you can install from GitHub (replace `1.3.2` with the version you need):
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.3.1
+      ref: v1.3.2
 ```
 
 ## Usage

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,7 @@
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 推荐升级：** v1.3.1 在 v1.3.0 的网络批量操作、导出敏感字段遮蔽、一键复制 cURL、告警系统（悬浮球未读红点）基础上，新增告警同源节流（避免持续超阈值或请求突发的告警风暴）。建议所有用户升级到 `^1.3.1`。
+> **🔔 推荐升级：** v1.3.2 在 v1.3.1 的告警同源节流、v1.3.0 的网络批量操作、导出敏感字段遮蔽、一键复制 cURL、告警系统（悬浮球未读红点）基础上，修复了网络请求耗时在响应到达前被提前计算的问题。建议所有用户升级到 `^1.3.2`。
 
 🌐 **[官方网站](https://www.zerolabsco.com/)**
 
@@ -40,19 +40,19 @@
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.1
+  zero_inspector_kit: ^1.3.2
 ```
 
 ### GitHub
 
-或者，你也可以从 GitHub 安装（将 `1.3.1` 替换为你需要的版本号）：
+或者，你也可以从 GitHub 安装（将 `1.3.2` 替换为你需要的版本号）：
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.3.1
+      ref: v1.3.2
 ```
 
 ## 使用方法

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,7 +8,7 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.1
+  zero_inspector_kit: ^1.3.2
 ```
 
 Then run:

--- a/lib/src/services/inspector_service.dart
+++ b/lib/src/services/inspector_service.dart
@@ -136,6 +136,11 @@ class InspectorService extends ChangeNotifier {
   /// [responseBody] 响应体数据 / Response body data
   /// [statusCode] HTTP状态码 / HTTP status code
   /// [body] 请求体数据 / Request body data
+  ///
+  /// 仅当 [statusCode] 非空时才视为"响应已到达"并设置 responseTime / duration；
+  /// 仅更新请求体（body）时不会过早标记请求已完成。
+  /// Only treats the update as a response arrival when [statusCode] is non-null;
+  /// updating only the request body (body) will not prematurely mark the request complete.
   void updateNetworkRequest(
     String id, {
     dynamic responseBody,
@@ -145,9 +150,23 @@ class InspectorService extends ChangeNotifier {
     final index = _indexOfNetworkRequest(id);
     if (index != -1) {
       final request = _networkRequests.elementAt(index);
-      final now = DateTime.now().millisecondsSinceEpoch;
-      final responseTime = request.responseTime ?? now;
-      final duration = responseTime - request.requestTime;
+
+      // 仅当 statusCode 被提供时，才视为响应到达，更新 responseTime / duration。
+      // 仅提供 body（请求体捕获）时不应设置 responseTime，否则会导致耗时计算错误。
+      // Only set responseTime when statusCode is provided (indicates response arrival).
+      // Providing only body (request body capture) must not set responseTime,
+      // otherwise duration is calculated incorrectly.
+      final int? responseTime;
+      final int? duration;
+      if (statusCode != null) {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        responseTime = request.responseTime ?? now;
+        duration = responseTime - request.requestTime;
+      } else {
+        responseTime = request.responseTime;
+        duration = request.duration;
+      }
+
       final updated = request.copyWith(
         responseBody: responseBody ?? request.responseBody,
         statusCode: statusCode ?? request.statusCode,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zero_inspector_kit
 description: A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/zero-labsco/zero_inspector_kit
 repository: https://github.com/zero-labsco/zero_inspector_kit
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -903,4 +903,159 @@ void main() {
       expect(updated.responseBody, equals('Service Unavailable'));
     });
   });
+
+  /// =======================================================================
+  /// InspectorService.updateNetworkRequest — responseTime 时机测试
+  /// InspectorService.updateNetworkRequest — responseTime timing tests
+  /// =======================================================================
+  group('InspectorService.updateNetworkRequest responseTime', () {
+    setUp(() {
+      InspectorService.instance.clearNetworkRequests();
+    });
+
+    tearDown(() {
+      InspectorService.instance.clearNetworkRequests();
+    });
+
+    test(
+      '仅更新 body 时不应设置 responseTime / Updating only body must not set responseTime',
+      () {
+        final service = InspectorService.instance;
+        final requestTime = DateTime.now().millisecondsSinceEpoch;
+
+        // 添加请求 / Add request
+        service.addNetworkRequest(
+          NetworkRequest(
+            id: 'test-1',
+            method: 'POST',
+            url: 'https://api.example.com/data',
+            requestTime: requestTime,
+          ),
+        );
+
+        // 仅更新请求体（无 statusCode）— 模拟拦截器捕获请求体
+        // Update only request body (no statusCode) — simulates interceptor
+        // capturing request body
+        service.updateNetworkRequest('test-1', body: '{"key":"value"}');
+
+        final request = service.networkRequests.firstWhere(
+          (r) => r.id == 'test-1',
+        );
+        expect(request.body, equals('{"key":"value"}'));
+        // 关键断言：responseTime 和 duration 不应被设置
+        // Key assertion: responseTime and duration must NOT be set
+        expect(
+          request.responseTime,
+          isNull,
+          reason: 'responseTime should not be set when only body is updated',
+        );
+        expect(
+          request.duration,
+          isNull,
+          reason: 'duration should not be set when only body is updated',
+        );
+      },
+    );
+
+    test(
+      '提供 statusCode 时应设置 responseTime / Providing statusCode should set responseTime',
+      () {
+        final service = InspectorService.instance;
+        final requestTime = DateTime.now().millisecondsSinceEpoch;
+
+        service.addNetworkRequest(
+          NetworkRequest(
+            id: 'test-2',
+            method: 'GET',
+            url: 'https://api.example.com/data',
+            requestTime: requestTime,
+          ),
+        );
+
+        // 更新响应（含 statusCode）— 模拟响应到达
+        // Update response (with statusCode) — simulates response arrival
+        service.updateNetworkRequest(
+          'test-2',
+          statusCode: 200,
+          responseBody: 'ok',
+        );
+
+        final request = service.networkRequests.firstWhere(
+          (r) => r.id == 'test-2',
+        );
+        expect(request.statusCode, equals(200));
+        expect(request.responseBody, equals('ok'));
+        expect(
+          request.responseTime,
+          isNotNull,
+          reason: 'responseTime must be set when statusCode is provided',
+        );
+        expect(
+          request.duration,
+          isNotNull,
+          reason: 'duration must be set when statusCode is provided',
+        );
+      },
+    );
+
+    test(
+      '先更新 body 再更新响应：responseTime 应为响应到达时间 / '
+      'Update body then response: responseTime should be response arrival time',
+      () {
+        final service = InspectorService.instance;
+        final requestTime = DateTime.now().millisecondsSinceEpoch;
+
+        service.addNetworkRequest(
+          NetworkRequest(
+            id: 'test-3',
+            method: 'POST',
+            url: 'https://api.example.com/data',
+            requestTime: requestTime,
+          ),
+        );
+
+        // 步骤 1：仅更新请求体（HTTP 拦截器在 close() 中调用）
+        // Step 1: Update only request body (called by HTTP interceptor in close())
+        service.updateNetworkRequest('test-3', body: '{"key":"value"}');
+
+        // 验证中间状态 / Verify intermediate state
+        var request = service.networkRequests.firstWhere(
+          (r) => r.id == 'test-3',
+        );
+        expect(
+          request.responseTime,
+          isNull,
+          reason: 'responseTime must be null after body-only update',
+        );
+
+        // 步骤 2：响应到达（含 statusCode）
+        // Step 2: Response arrives (with statusCode)
+        service.updateNetworkRequest(
+          'test-3',
+          statusCode: 201,
+          responseBody: 'created',
+        );
+
+        // 验证最终状态 / Verify final state
+        request = service.networkRequests.firstWhere((r) => r.id == 'test-3');
+        expect(request.statusCode, equals(201));
+        expect(request.body, equals('{"key":"value"}'));
+        expect(
+          request.responseTime,
+          isNotNull,
+          reason: 'responseTime must be set after response update',
+        );
+        expect(
+          request.duration,
+          isNotNull,
+          reason: 'duration must be set after response update',
+        );
+        expect(
+          request.duration,
+          greaterThanOrEqualTo(0),
+          reason: 'duration must be non-negative',
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
### Summary / 摘要

Fix network request duration being calculated prematurely (before the response has actually arrived), and bump the package to 1.3.2 with updated docs.

修复网络请求耗时在响应真正到达前即被错误计算的问题，并将包版本升级到 1.3.2、同步相关文档。

### Changes / 变更

- `InspectorService.updateNetworkRequest` now only sets `responseTime` / `duration` when `statusCode` is provided (response arrival). Updating only the request body (e.g. HTTP interceptor capturing the body in `close()`) keeps them unset, so requests are no longer prematurely marked complete.
  `InspectorService.updateNetworkRequest` 现在仅在提供 `statusCode`（响应到达）时设置 `responseTime` 与 `duration`；仅更新请求体（如 HTTP 拦截器在 `close()` 中捕获请求体）时保留原值，不再过早标记请求完成。
- Add `InspectorService.updateNetworkRequest responseTime` test group in `test/models_test.dart` (body-only update, statusCode set, body-then-response sequence).
  在 `test/models_test.dart` 新增 `InspectorService.updateNetworkRequest responseTime` 测试组（仅更新 body、提供 statusCode、先 body 后响应时序）。
- Bump `pubspec.yaml` to `1.3.2`; update `CHANGELOG.md` (new `## 1.3.2` section), `README.md` / `README_zh.md` (upgrade note + dependency `^1.3.2` + GitHub `ref: v1.3.2`), and `docs/Installation.md` (`^1.3.2`).
  升级 `pubspec.yaml` 至 `1.3.2`；更新 `CHANGELOG.md`（新增 `## 1.3.2` 段）、`README.md` / `README_zh.md`（升级提示 + 依赖 `^1.3.2` + GitHub `ref: v1.3.2`）及 `docs/Installation.md`（`^1.3.2`）。
- Add `.trae-html-share-packages/` to `.gitignore` to prevent Trae IDE share/export zips from being committed.
  在 `.gitignore` 增加 `.trae-html-share-packages/`，避免 Trae IDE 分享导出包被误提交。
- Document the PR body template (EN-primary / ZH-secondary, branded **Zero Buddy**) and fix the archive-branch naming (`release-vX.Y.Z`) in `AGENTS.md`.
  在 `AGENTS.md` 登记 PR 正文模板（英文为主、中文为辅，署名 **Zero Buddy**），并修正归档分支名为 `release-vX.Y.Z`。

### Context / 背景

The Trae agent branch `trae/agent-FGLYmH` contained this bug fix mixed with two `.trae-html-share-packages/*.zip` files (IDE export artifacts that should not be in the repo). This PR applies only the code fix and its tests, excludes the zips, bumps the version, refreshes the docs, and records the PR body convention in `AGENTS.md`.

Trae 分支 `trae/agent-FGLYmH` 把这个缺陷修复和两个 `.trae-html-share-packages/*.zip`（不应入仓的 IDE 导出产物）混在一起。本 PR 仅应用代码修复与测试、排除 zip、升级版本、刷新文档，并将 PR 正文约定写入 `AGENTS.md`。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] `dart format` run, `flutter analyze` clean on changed files / 已跑格式化、改动文件分析无错误
- [ ] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [x] New unit tests in `test/models_test.dart` cover the timing fix
- [x] Pushed to `fix/network-response-time`

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
