### PR TITLE
docs: align archive branch naming to release/vX.Y.Z

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ Notes / 说明:
    - `flutter pub publish --dry-run` — confirm the package scores well on `pana` and no files are unintentionally excluded.
 4. Commit on a branch, open PR, merge to `main` after the 3 required checks pass.
 5. Tag (drives publishing): `git tag vX.Y.Z <commit> && git push origin vX.Y.Z`. The `vX.Y.Z` tag — NOT a branch — triggers `pub-publish.yml`. Never name a branch `vX.Y.Z`; it collides with the tag refspec and breaks `git push`.
-6. Archive branch (optional, for release snapshots): create `release-vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release-vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots. The remote `v*` archive branches were renamed to `release-v*` to prevent tag/branch refspec ambiguity.
-   - 远程 `v*` 归档分支已重命名为 `release-*` 以避免 tag 与分支的 refspec 歧义。
+6. Archive branch (optional, for release snapshots): create `release/vX.Y.Z` from the tagged commit via explicit refspec to avoid the tag/branch collision, e.g. `git push origin <commit>:refs/heads/release/vX.Y.Z`. These branches are inert (no CI triggers on them) and serve only as frozen snapshots. The remote `v*` archive branches were renamed to `release/v*` to prevent tag/branch refspec ambiguity.
+   - 远程 `v*` 归档分支已重命名为 `release/v*` 以避免 tag 与分支的 refspec 歧义。
 7. `pub-publish.yml` publishes via `k-paxian/dart-package-publisher@v1.6` using the `PUB_CREDENTIALS_JSON` secret (fields `accessToken`, `refreshToken`; set `flutter: true`). Do NOT pass OIDC fields (`idToken` / `tokenEndpoint` / `scopes`); the action does not support them and emits invalid-input warnings.
    - Note: `k-paxian` internally uses older actions that emit Node 20 deprecation warnings. This is accepted (B1 decision); functionality is unaffected.
 


### PR DESCRIPTION
### Summary / 摘要

Align the archive branch naming convention in AGENTS.md to `release/vX.Y.Z` (with slash) instead of the incorrect `release-vX.Y.Z` (with hyphen). / 将 AGENTS.md 中归档分支命名规范从错误的 `release-vX.Y.Z`（连字符）修正为正确的 `release/vX.Y.Z`（斜杠）。

### Changes / 变更

- Fixed the archive-branch naming in the Release section of AGENTS.md to use `release/vX.Y.Z`. / 修正了 AGENTS.md「发布与发布」段落中归档分支命名为 `release/vX.Y.Z`。
- Kept the rest of the doc (re-tagging and checklist sections) consistent, which already used the correct `release/vX.Y.Z` form. / 文档其余部分（重新打 tag、检查清单）已使用正确的 `release/vX.Y.Z`，本次保持一致。

### Context / 背景

A release was cut as `release/v1.3.2` to match the existing archive branches (`release/v1.0.4` … `release/v1.3.1`), but AGENTS.md still described the name as `release-vX.Y.Z`, which would mislead future agents into creating the wrong branch. / 实际发布的归档分支命名为 `release/v1.3.2`，与历史归档分支一致，但 AGENTS.md 中仍写作 `release-vX.Y.Z`，会误导后续 AI 或贡献者创建错误命名的分支。

### Checklist / 检查项

- [ ] Title follows Conventional Commits / 标题符合约定式提交
- [ ] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [ ] Verify AGENTS.md shows `release/vX.Y.Z` consistently / 确认 AGENTS.md 中统一使用 `release/vX.Y.Z`
- [ ] No code changes, so `flutter test` is unaffected / 无代码改动，`flutter test` 不受影响

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
