### PR TITLE
docs: fix residual 1.3.2 in README and document version-bump checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,18 @@ Notes / 说明:
 
 ### Release and publish
 1. Bump `version` in `pubspec.yaml` (semver; major bump for breaking public API).
+   **Mandatory version-bump checklist — every one of these MUST be updated to the new version `X.Y.Z` (and the old version string removed). Missing any of them is a recurring, real mistake — verify each explicitly, do not assume a previous pass covered them:**
+   - [ ] `pubspec.yaml` → `version: X.Y.Z`
+   - [ ] `ios/zero_inspector_kit.podspec` → `s.version = 'X.Y.Z'` (this file is often stale; always check it)
+   - [ ] `README.md`:
+     - [ ] the `^X.Y.Z` dependency constraint in the install snippet
+     - [ ] the `` `X.Y.Z` `` placeholder in "install from GitHub" (replace `X.Y.Z` with the version you need)
+     - [ ] the `ref: vX.Y.Z` in the GitHub install git block
+     - NOTE: historical prose like "on top of vX.(Y-1)'s ..." refers to the PREVIOUS version and must NOT be bumped — only literal version references above change.
+   - [ ] `README_zh.md`: same three spots as `README.md` (`^X.Y.Z`, `` `X.Y.Z` `` placeholder, `ref: vX.Y.Z`). Historical prose stays.
+   - [ ] `docs/Installation.md`: the `^X.Y.Z` dependency constraint.
+   - [ ] `CHANGELOG.md`: add a new `## X.Y.Z` section at the top describing the changes.
+   - Grep sanity check before committing: `grep -rn "old_version" README.md README_zh.md docs/Installation.md` must return NOTHING (only legitimate historical prose may remain).
 2. Update `README.md` / `CHANGELOG.md` as needed.
 3. Locally verify before pushing:
    - `flutter analyze` — must pass with no errors.
@@ -135,4 +147,4 @@ When re-tagging after a fix, force-update both the `vX.Y.Z` tag and the `release
 - [ ] Use a typed branch (`feat/...`) and a Conventional Commits PR title.
 - [ ] Ensure the 3 required status checks pass before requesting review/merge.
 - [ ] For user-facing changes, update `README.md` and the `docs/` site.
-- [ ] For releases, bump `version`, update changelog, tag `vX.Y.Z` (triggers publish), and optionally push a `release/vX.Y.Z` archive branch via explicit refspec.
+- [ ] For releases, bump `version` AND follow the **Mandatory version-bump checklist** under "Release and publish" above (pubspec, iOS podspec, README.md, README_zh.md, docs/Installation.md, CHANGELOG.md — grep for the old version string to confirm nothing is left). Tag `vX.Y.Z` (triggers publish), and optionally push a `release/vX.Y.Z` archive branch via explicit refspec.

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.2
+  zero_inspector_kit: ^1.3.3
 ```
 
 ### GitHub
 
-Alternatively, you can install from GitHub (replace `1.3.2` with the version you need):
+Alternatively, you can install from GitHub (replace `1.3.3` with the version you need):
 
 ```yaml
 dependencies:


### PR DESCRIPTION
### Summary / 摘要

Fix the two remaining `1.3.2` references in README.md install snippets and add a mandatory version-bump checklist to AGENTS.md so future releases don't miss version strings. / 修复 README.md 安装示例里残留的两处 1.3.2 引用，并在 AGENTS.md 新增强制版本升级检查清单，避免日后发布漏改版本号。

### Changes / 变更

- README.md: changed the leftover `^1.3.2` dependency constraint and the `1.3.2` GitHub-install placeholder to `^1.3.3` / `1.3.3`. Historical prose mentioning `v1.3.2` is intentionally kept. / README.md：将残留的 `^1.3.2` 依赖约束与 `1.3.2` GitHub 安装占位改为 `^1.3.3` / `1.3.3`；历史叙述中提及的 `v1.3.2` 按设计保留。
- AGENTS.md: added a **Mandatory version-bump checklist** under "Release and publish" listing every file that must be updated on a version bump (`pubspec.yaml`, `ios/zero_inspector_kit.podspec`, `README.md`, `README_zh.md`, `docs/Installation.md`, `CHANGELOG.md`) plus a grep sanity check, and referenced it from the new-feature checklist. / AGENTS.md：在「Release and publish」下新增强制版本升级检查清单，列出每次 bump 版本必须更新的所有文件，并加入提交前 grep 旧版本号的校验，同时在新功能清单中引用。

### Context / 背景

During the 1.3.3 release, two `1.3.2` strings were left in README.md install instructions, and the iOS podspec had also drifted to 1.2.2 — a recurring class of mistake. This PR fixes the README slip and hard-codes the full list of version-touch points into AGENTS.md so AI agents and contributors stop missing them. / 在 1.3.3 发布过程中，README.md 安装说明里漏改了两处 1.3.2，且 iOS podspec 也曾滞后到 1.2.2 —— 这是一类反复出现的错误。本 PR 修正 README 疏漏，并把所有版本相关改动点固化进 AGENTS.md，避免 AI 或贡献者再次漏改。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [x] `grep -rn "1.3.2" README.md README_zh.md docs/Installation.md` returns only intended historical prose / 仅剩有意保留的历史叙述
- [x] No code changes, so `flutter analyze` / `flutter test` are unaffected / 无代码改动，flutter analyze / flutter test 不受影响

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
