### PR TITLE
feat: add touch interaction to memory trend chart and fix panel auto-close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Notes / 说明:
    - [ ] `README.md`:
      - [ ] the `^X.Y.Z` dependency constraint in the install snippet
      - [ ] the `` `X.Y.Z` `` placeholder in "install from GitHub" (replace `X.Y.Z` with the version you need)
-     - [ ] the `ref: vX.Y.Z` in the GitHub install git block
+     - [ ] the `ref: release/vX.Y.Z` in the GitHub install git block (use the `release/vX.Y.Z` archive **branch**, NOT the `vX.Y.Z` tag — the tag collides with branch refspec and breaks `git push`)
      - [ ] the "🔔 Upgrade recommended" callout — the leading version token `vX.Y.Z` that anchors the current release's summary MUST be bumped to the new version (e.g. `v1.3.4 cleans up ...`); also update its trailing "upgrade to `^X.Y.Z`" advice.
      - NOTE: historical prose like "on top of vX.(Y-1)'s ..." refers to the PREVIOUS version and must NOT be bumped — only literal version references above change. The leading version in the upgrade callout is NOT historical prose; it describes the new release and must be bumped.
    - [ ] `README_zh.md`: same spots as `README.md` (`^X.Y.Z`, `` `X.Y.Z` `` placeholder, `ref: vX.Y.Z`, and the leading `vX.Y.Z` in the "🔔 推荐升级：" callout). Historical prose stays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.3.6
+
+> **📊 趋势图交互增强 / Trend chart interaction:** 内存趋势图现在支持触摸交互——点击或拖动折线图区域可高亮最近的数据点，显示十字准线与浮动 Tooltip（精确数值 + 相对"现在"的时间偏移）。未触摸时仍显示 Current / Peak / Min 图例。无新增公共 API，组件沿用原构造签名。
+> The memory trend chart now supports touch interaction — tap or drag on the chart to highlight the nearest data point, showing a crosshair plus a floating tooltip with the exact value and the time offset from "now". The Current / Peak / Min legend is still shown when not touched. No new public API; the widget keeps its original constructor signature.
+
+- 内存 / Memory
+  - 新增趋势图触摸交互：点击 / 拖动定位最近数据点，绘制十字准线并高亮该点（蓝色外圈 + 实心点）
+  - Added trend chart touch interaction: tap/drag locates the nearest data point, drawing a crosshair and highlighting it (blue ring + solid dot)
+  - 触摸时顶部浮出 Tooltip，显示该时刻的精确数值与相对时间（如 `-1m 23s`）
+  - A floating tooltip appears on touch, showing the exact value and relative time (e.g. `-1m 23s`)
+  - 未触摸时保持原 Current / Peak / Min 图例展示，交互状态由 `StatefulWidget` 本地维护，不影响采样逻辑
+  - Untouched state keeps the original Current / Peak / Min legend; interaction state is local to a `StatefulWidget` and does not affect sampling logic
+
 ## 1.3.5
 
 > **🚀 检查器能力扩展 / Inspector capability expansion：** 本版本新增网络 **Timeline 瀑布图**、**系统分享**导出内容（基于 `share_plus`）、**Widget 检查器**（树形展示业务 Widget 树，自动排除检查器自身浮层），并将 **Database 查看器**扩展到 **SharedPreferences** 与 **Hive**。Widget 检查器与 Network Timeline 均**默认关闭、通过面板顶部开关控制（与内存监控一致）**。公共 API 新增 `SharedPrefsProvider`、`HiveProvider`、`NetworkTimeline`、`WidgetTreeInspector`、`WidgetTreeService`、`InspectorSwitchCard`，以及一行注册方法 `ZeroInspectorKit.registerSharedPrefs()` / `registerHive()` 与 `init` 配置项 `enableWidgetInspector` / `enableNetworkTimeline`。

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 Upgrade recommended:** v1.3.5 extends the inspector — adds a network **Timeline / waterfall view** (per-request duration & overlap), **system sharing** of exported logs/requests via `share_plus`, a **Widget inspector** (breadcrumb-navigation business widget tree), and a **Database viewer** that now also covers **SharedPreferences** and **Hive** (registered via the one-line API) — on top of v1.3.4's metadata/docs cleanup, v1.3.3's hardened network interception, v1.3.2's network duration fix, v1.3.1's per-source alert throttling, and v1.3.0's network batch operations, sensitive-field masking on export, one-click cURL copy, and the alert system with an unread badge. All users are advised to upgrade to `^1.3.5`.
+> **🔔 Upgrade recommended:** v1.3.6 extends the inspector — adds **touch interaction to the memory trend chart** (tap/drag to highlight the nearest data point with a crosshair and a floating tooltip showing the exact value and timestamp) — on top of v1.3.5's network Timeline waterfall view, system sharing via `share_plus`, Widget inspector, and SharedPreferences/Hive database support, v1.3.4's metadata/docs cleanup, v1.3.3's hardened network interception, v1.3.2's network duration fix, v1.3.1's per-source alert throttling, and v1.3.0's network batch operations, sensitive-field masking on export, one-click cURL copy, and the alert system with an unread badge. All users are advised to upgrade to `^1.3.6`.
 
 🌐 **[Official Website](https://www.zerolabsco.com/)**
 
@@ -41,19 +41,19 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.5
+  zero_inspector_kit: ^1.3.6
 ```
 
 ### GitHub
 
-Alternatively, you can install from GitHub (replace `1.3.5` with the version you need):
+Alternatively, you can install from GitHub (replace `1.3.6` with the version you need):
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.3.5
+      ref: release/v1.3.6
 ```
 
 ## Usage

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,7 @@
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 推荐升级：** v1.3.5 扩展了检查器能力 —— 新增网络 **Timeline 瀑布图**（单请求耗时与并发重叠可视化）、通过 `share_plus` **系统分享**导出的日志/请求、**Widget 检查器**（面包屑导航式业务 Widget 树），以及 **Database 查看器**现在也覆盖 **SharedPreferences** 与 **Hive**（通过一行 API 注册）—— 在 v1.3.4 元数据/文档清理、v1.3.3 强化的网络拦截、v1.3.2 修复网络请求耗时、v1.3.1 按来源告警节流、以及 v1.3.0 网络批量操作、导出敏感字段脱敏、一键复制 cURL、带未读角标的告警系统之上。建议所有用户升级到 `^1.3.5`。
+> **🔔 推荐升级：** v1.3.6 扩展了检查器能力 —— 新增内存**趋势图触摸交互**（点击或拖动高亮最近数据点，显示十字准线与浮动 Tooltip 精确数值及时间戳）—— 在 v1.3.5 网络 Timeline 瀑布图、`share_plus` 系统分享、Widget 检查器、SharedPreferences/Hive 数据库支持、v1.3.4 元数据/文档清理、v1.3.3 强化的网络拦截、v1.3.2 修复网络请求耗时、v1.3.1 按来源告警节流、以及 v1.3.0 网络批量操作、导出敏感字段脱敏、一键复制 cURL、带未读角标的告警系统之上。建议所有用户升级到 `^1.3.6`。
 
 🌐 **[官方网站](https://www.zerolabsco.com/)**
 
@@ -40,19 +40,19 @@
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.5
+  zero_inspector_kit: ^1.3.6
 ```
 
 ### GitHub
 
-或者，你也可以从 GitHub 安装（将 `1.3.5` 替换为你需要的版本号）：
+或者，你也可以从 GitHub 安装（将 `1.3.6` 替换为你需要的版本号）：
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: v1.3.5
+      ref: release/v1.3.6
 ```
 
 ## 使用方法

--- a/TODO.md
+++ b/TODO.md
@@ -120,22 +120,26 @@
 
 ### 低优先级
 
-- [ ] **文件导出 + 系统分享 / File export & system share**
-  - **状态**: 待实现 / To be implemented
+- [x] **文件导出 + 系统分享 / File export & system share** ✅ 已完成 / Done
+  - **状态**: 已实现 / Implemented
   - **实现方案 / Implementation**:
-    - 将数据写入临时文件（如 `_inspector_export_*.json`）
-    - Write data to temp file (e.g. `_inspector_export_*.json`)
-    - 通过 `share_plus` 调用系统分享面板（微信/邮件/Drive 等）
-    - Use `share_plus` to invoke system share panel (WeChat/Email/Drive etc.)
+    - 新增 `share_plus: ^13.2.0` 依赖（`pubspec.yaml`）
+    - Added `share_plus: ^13.2.0` dependency (`pubspec.yaml`)
+    - 数据写入应用临时文件（`getTemporaryDirectory` 下的 `zero_inspector_logs.*` / `zero_inspector_net.*`）
+    - Write data to app temp file (`zero_inspector_logs.*` / `zero_inspector_net.*` under `getTemporaryDirectory`)
+    - 通过 `SharePlus.instance.share(ShareParams(files: [...]))` 唤起系统分享面板（微信/邮件/Drive 等）
+    - Invoke system share sheet via `SharePlus.instance.share(...)` (WeChat/Email/Drive etc.)
     - 用户可选「复制到剪贴板」或「保存/分享为文件」
     - User can choose "copy to clipboard" or "save/share as file"
-    - 需要额外依赖 `share_plus`（约 4KB，Android/iOS 原生实现）
-    - Requires extra dependency `share_plus` (~4KB, native Android/iOS implementation)
+    - 导出格式覆盖 JSON / 纯文本 / CSV / HAR / cURL（HAR 可直接导入 Chrome DevTools / Charles）
+    - Export formats: JSON / plain text / CSV / HAR / cURL (HAR importable into Chrome DevTools / Charles)
+    - 导出时对敏感头（Authorization/Cookie 等）支持遮蔽（`maskSensitive`）
+    - Sensitive headers (Authorization/Cookie etc.) are masked on export (`maskSensitive`)
   - **涉及文件 / Related files**:
-    - `lib/src/services/export_service.dart`（扩展 / extended）
+    - `lib/src/services/export_service.dart`（扩展：`writeToFile` / `exportLogsToFile` / `exportNetToFile` / `shareFile` / `exportLogsAndShare` / `exportNetAndShare` 等）
     - `lib/src/ui/log_viewer.dart`（扩展 / extended）
     - `lib/src/ui/network_viewer.dart`（扩展 / extended）
-    - `pubspec.yaml`（新增依赖 / add dependency）
+    - `pubspec.yaml`（新增 `share_plus` 依赖 / add `share_plus` dependency）
 
 ---
 
@@ -143,17 +147,19 @@
 
 ### 中优先级
 
-- [ ] **趋势图触摸交互 / Trend chart touch interaction**
-  - **状态**: 待实现 / To be implemented
+- [x] **趋势图触摸交互 / Trend chart touch interaction** ✅ 已完成 / Done
+  - **状态**: 已实现 / Implemented
   - **实现方案 / Implementation**:
-    - 触摸折线图显示指示器（Tooltip 显示精确数值和时间）
-    - Touch on chart shows tooltip with exact value and timestamp
-    - 支持手指滑动查看历史数据点
-    - Support finger drag to browse historical data points
-    - Y 轴标签动态自适应当前最大值
-    - Y-axis labels auto-adapt to current max value
+    - 触摸折线图显示十字准线 + 高亮最近数据点，并浮出 Tooltip 显示精确数值与相对时间（如 `-1m 23s`）
+    - Touch on chart shows crosshair + highlighted nearest point, popping a tooltip with exact value and relative time (e.g. `-1m 23s`)
+    - 支持手指拖动实时跟手浏览历史数据点（onPanDown/onPanUpdate 定位最近索引，onPanEnd 复位图例）
+    - Support finger drag to browse historical data points in real time (onPanDown/onPanUpdate locate nearest index, onPanEnd resets to legend)
+    - 未触摸时仍显示 Current / Peak / Min 图例；交互状态由 `StatefulWidget` 本地维护，不改变采样逻辑
+    - Legend (Current / Peak / Min) shown when untouched; interaction state is local to a `StatefulWidget`, no change to sampling
+    - Y 轴标签动态自适应当前最大值（max / 中值 / min 三档）
+    - Y-axis labels auto-adapt to current max value (max / mid / min)
   - **涉及文件 / Related files**:
-    - `lib/src/ui/memory_trend_chart.dart`（扩展 / extended）
+    - `lib/src/ui/memory_trend_chart.dart`（扩展：`MemoryTrendChart` 改为 `StatefulWidget`，`_LineChartPainter` 新增 `highlightIndex` 十字准线绘制 / extended）
 
 - [ ] **内存历史窗口可配置 / Configurable memory history window**
   - **状态**: 待实现 / To be implemented
@@ -172,18 +178,22 @@
 
 ### 中优先级
 
-- [ ] **网络请求 Timeline / 瀑布图 / Network request timeline view**
-  - **状态**: 待实现 / To be implemented
+- [x] **网络请求 Timeline / 瀑布图 / Network request timeline view** ✅ 已完成 / Done
+  - **状态**: 已实现 / Implemented
   - **实现方案 / Implementation**:
-    - 按时间轴展示所有请求的并行关系
-    - Show parallel request relationships along a time axis
-    - 每个请求的耗时分解（发送/等待/接收）
-    - Per-request duration breakdown (send/wait/receive)
-    - 慢请求预警（>3s 标红）
-    - Slow request warning (>3s highlighted in red)
+    - 以统一时间窗（最早请求 → 最晚响应，两端各留 5% 余量）展示所有请求的并行关系
+    - Show parallel request relationships along a shared time axis (earliest start → latest finish, 5% safe margin on both ends)
+    - 每个请求分解为「等待段」（accent 色条）与「响应段」（success 色圆点），点击行可下钻详情
+    - Per-request breakdown into a "wait" segment (accent bar) and "response" marker (success dot); tap a row to drill into detail
+    - 左侧方法徽标（按 GET/POST/... 着色）+ URL 摘要，右侧轨道按比例映射；列表自身 `ListView` 滚动，固定行高，无无限高度溢出风险
+    - Left method badge (colored by GET/POST/...) + URL summary, right track scaled to ratio; list scrolls via its own `ListView` with fixed row height (no unbounded-height overflow)
+    - 顶部图例 + 请求总数；暂无请求时显示空状态
+    - Legend + total count on top; empty state when no requests
   - **涉及文件 / Related files**:
-    - `lib/src/ui/network_timeline.dart`（新增 / new）
-    - `lib/src/ui/network_viewer.dart`（扩展 / extended）
+    - `lib/src/ui/network_timeline.dart`（新增 / new）：`NetworkTimeline` + `_TimelineRow`
+    - `lib/src/ui/network_viewer.dart`（扩展：在查看器中集成 Timeline 视图 / extended）
+    - `lib/zero_inspector_kit.dart`（注册导出 / registered for export）
+    - `lib/src/services/inspector_service.dart`（引用 / referenced）
 
 - [ ] **网络请求更多筛选维度 / More network request filters**
   - **状态**: 待实现 / To be implemented
@@ -237,20 +247,21 @@
 
 ### 中优先级
 
-- [ ] **SharedPreferences / UserDefaults 查看器 / SharedPreferences viewer**
-  - **状态**: 待实现 / To be implemented
+- [x] **SharedPreferences 查看器 / SharedPreferences viewer** ✅ 已完成 / Done
+  - **状态**: 已实现（并入 Database 体系）/ Implemented (merged into Database)
   - **实现方案 / Implementation**:
-    - 列出所有 SharedPreferences 文件
-    - List all SharedPreferences files
-    - 查看 key-value 数据（支持 String/int/bool 等类型）
-    - View key-value data (supports String/int/bool types)
-    - 支持搜索和导出
-    - Support search and export
-    - 通过 `getSharedPreferences` 读取
-    - Read via `getSharedPreferences`
+    - 作为「自定义数据库源」并入 Database：SP 键值对被呈现为单库单表 `preferences`（`key` / `type` / `value` 三列），复用 `DatabaseViewer` 的浏览、搜索、导出流程
+    - Merged into Database as a "custom DB source": SP key-values are exposed as a single DB / table `preferences` (`key`/`type`/`value`), reusing `DatabaseViewer`'s browse, search & export flow
+    - 通过抽象契约 `SharedPrefsLike`（仅声明查看所需方法）适配，**插件自身不依赖 `shared_preferences`**，用户传入自己持有的实例即可兼容任意版本
+    - Adapted via abstract `SharedPrefsLike` contract; the plugin does NOT depend on `shared_preferences` — callers pass their own instance for any version compatibility
+    - 一行注册：`ZeroInspectorKit.registerSharedPrefs(SharedPreferencesAdapter(prefs))`
+    - One-line registration: `ZeroInspectorKit.registerSharedPrefs(SharedPreferencesAdapter(prefs))`
+    - 支持按 key 关键字搜索、按类型识别（bool/int/double/String/List<String>）
+    - Supports key-keyword search and type detection (bool/int/double/String/List<String>)
   - **涉及文件 / Related files**:
-    - `lib/src/services/shared_prefs_service.dart`（新增 / new）
-    - `lib/src/ui/shared_prefs_viewer.dart`（新增 / new）
+    - `lib/src/services/shared_prefs_provider.dart`（新增：`SharedPrefsLike` / `SharedPreferencesAdapter` / `SharedPrefsProvider`）
+    - `lib/zero_inspector_kit.dart`（新增 `registerSharedPrefs()` 公开 API + 导出）
+    - `lib/src/ui/database_viewer.dart`（复用，无单独 SP 查看器页面 / reused, no separate SP viewer page）
 
 ---
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,7 +8,7 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.3.5
+  zero_inspector_kit: ^1.3.6
 ```
 
 Then run:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:logger/logger.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
@@ -148,6 +149,17 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
   final _httpClient = HttpClient();
   int _requestCount = 0;
 
+  // 第三方 logger 演示用的实例（懒创建），与"检查器日志"完全解耦。
+  // Lazily-created instance for the third-party logger demo, fully decoupled
+  // from the inspector's own logs.
+  Logger? _logger;
+  // 是否开启了"检查器 → logger"转发。只在用户显式开关时才设置全局回调，
+  // 关闭时复位为 null，避免污染后续所有日志捕获。
+  // Whether "inspector → logger" forwarding is on. The global callback is only
+  // set while the toggle is on, and reset to null when off, so it never leaks
+  // into unrelated log captures.
+  bool _forwardingToLogger = false;
+
   @override
   void initState() {
     super.initState();
@@ -220,6 +232,107 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
     }
   }
 
+  /// 演示日志查看器：通过 InspectorLogInterceptor 输出各层级、不同 tag 的日志，
+  /// 并故意抛出一个被捕获的异常（连同 stack），方便在 Log 查看器里演示分级、
+  /// 搜索与按 tag 筛选。
+  /// Demo the Log viewer: emit logs of every level with different tags via
+  /// InspectorLogInterceptor, plus a caught exception (with stack) so the Log
+  /// viewer can demo level filtering, search, and tag grouping.
+  void _emitDemoLogs() {
+    InspectorLog.v('Bootstrap sequence started', tag: 'lifecycle');
+    InspectorLog.d('Hydrating cached config from disk', tag: 'cache');
+    InspectorLog.i('User session restored (uid=1024)', tag: 'auth');
+    InspectorLog.i('Fetched 12 items from remote API', tag: 'network');
+    InspectorLog.w('Slow response: /feed took 1820ms', tag: 'network');
+    InspectorLog.w('Token expires in 90s, will refresh soon', tag: 'auth');
+    InspectorLog.e('Failed to decode push payload', tag: 'push');
+    try {
+      throw StateError('Simulated crash in background sync');
+    } catch (error, stack) {
+      InspectorLog.e('Background sync error: $error\n$stack', tag: 'sync');
+    }
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Emitted demo logs — open the Log viewer'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  /// 演示第三方日志库集成：使用 `logger` 包（pub.dev 上的 logger 2.x）输出日志。
+  /// 检查器会自动通过 print() 捕获这些日志（归类为 Info 级别），无需任何配置。
+  /// 本函数只负责"logger → 检查器"这一段（单向），不触碰全局转发状态，
+  /// 因此与 _emitDemoLogs 完全互不影响。
+  /// Demo third-party logger integration: emit logs via the `logger` package.
+  /// The inspector auto-captures them through print() (classified as Info), no
+  /// config needed. This only covers the "logger → inspector" direction and
+  /// never touches the global forwarding state, so it is fully independent of
+  /// _emitDemoLogs.
+  void _emitLoggerLogs() {
+    final logger = _logger ??= Logger(
+      printer: PrettyPrinter(methodCount: 0, errorMethodCount: 3),
+    );
+    logger.t('logger verbose: lazy-loaded feature flags');
+    logger.d('logger debug: cache hit ratio = 0.87');
+    logger.i('logger info: order #8852 created');
+    logger.w('logger warning: retry 2/3 after timeout');
+    logger.e(
+      'logger error: payment gateway returned 503',
+      error: 'gateway_unavailable',
+      stackTrace: StackTrace.current,
+    );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Emitted logger logs — auto-captured by Log viewer'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  /// 切换"检查器 → logger"转发开关。开启时设置一次全局回调，关闭时复位为
+  /// null，确保不影响其它演示（例如 demo 日志）的捕获行为。
+  /// Toggle the "inspector → logger" forwarding switch. When on, install the
+  /// global callback once; when off, reset it to null so other demos (e.g. demo
+  /// logs) are unaffected.
+  void _toggleLoggerForwarding() {
+    final logger = _logger ??= Logger(
+      printer: PrettyPrinter(methodCount: 0, errorMethodCount: 3),
+    );
+    setState(() {
+      _forwardingToLogger = !_forwardingToLogger;
+    });
+    if (_forwardingToLogger) {
+      InspectorLog.onLogCaptured = (entry) {
+        // 用 level.name 判断级别（无需直接引用插件的 LogLevel 类型）。
+        // Use level.name to avoid importing the internal LogLevel type.
+        final lvl = entry.level.name == 'error' ? Level.error : Level.info;
+        logger.log(lvl, '[inspector] ${entry.message}');
+      };
+    } else {
+      // 关闭时清除回调，避免永久污染后续日志捕获。
+      // Clear the callback when off so it never leaks into later captures.
+      InspectorLog.onLogCaptured = null;
+    }
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            _forwardingToLogger
+                ? 'Forwarding inspector logs → logger: ON'
+                : 'Forwarding inspector logs → logger: OFF',
+          ),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
   /// 触发一次强制掉帧：在 UI 线程做一段同步重计算，制造可见的 jank，
   /// 让 FPS 监控页能看到掉帧标记与 FPS 抖动。
   /// Force a jank: a blocking synchronous computation on the UI thread so the
@@ -259,6 +372,35 @@ class _ExampleHomePageState extends State<ExampleHomePage> {
             onPressed: _sendAllDemoRequests,
             icon: const Icon(Icons.cloud_download),
             label: const Text('Send mixed requests (GET/POST/PUT/DELETE)'),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton.icon(
+            onPressed: _emitDemoLogs,
+            icon: const Icon(Icons.message_outlined),
+            label: const Text('Emit demo logs (see Log viewer)'),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton.icon(
+            onPressed: _emitLoggerLogs,
+            icon: const Icon(Icons.library_books_outlined),
+            label: const Text('Emit logger logs (3rd-party)'),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton.icon(
+            onPressed: _toggleLoggerForwarding,
+            icon: Icon(
+              _forwardingToLogger
+                  ? Icons.link_off_outlined
+                  : Icons.link_outlined,
+            ),
+            style: _forwardingToLogger
+                ? ElevatedButton.styleFrom(backgroundColor: Colors.orange)
+                : null,
+            label: Text(
+              _forwardingToLogger
+                  ? 'Forward inspector logs → logger: ON'
+                  : 'Forward inspector logs → logger: OFF',
+            ),
           ),
           const SizedBox(height: 12),
           ElevatedButton.icon(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -706,7 +706,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.5"
+    version: "1.3.6"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.4"

--- a/ios/zero_inspector_kit.podspec
+++ b/ios/zero_inspector_kit.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'zero_inspector_kit'
-  s.version          = '1.3.5'
+  s.version          = '1.3.6'
   s.summary          = 'A Flutter plugin for in-app developer console.'
   s.description      = <<-DESC
 A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.

--- a/lib/src/ui/floating_button.dart
+++ b/lib/src/ui/floating_button.dart
@@ -343,23 +343,37 @@ class _FloatingInspectorButtonState extends State<FloatingInspectorButton>
 
   /// 构建展开的检查器面板（独立模式）/ Build expanded inspector panel (standalone mode)
   Widget _buildExpandedPanel() {
+    // 分层结构：底层关闭层（点击空白关闭）+ 上层面板（点击内部不关闭）。
+    // 避免 InspectorPanel 因内存监控高频 notifyListeners 重建时，被 Flutter
+    // 重新派发的合成指针事件命中全屏 GestureDetector 而误关面板。
+    // Layered: a full-screen close layer (tap empty area to close) under the
+    // centered panel that consumes taps. Prevents a synthetic pointer event
+    // (fired when InspectorPanel rebuilds from memory monitor notifications)
+    // from hitting the close gesture and auto-closing the panel.
     return Positioned(
       left: 0,
       top: 0,
       right: 0,
       bottom: 0,
-      child: GestureDetector(
-        onTap: _togglePanelInternal,
-        child: Container(
-          // 全透明遮罩，不阻挡背景显示 / Fully transparent overlay, doesn't block background
-          color: Colors.transparent,
-          child: Center(
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              onTap: _togglePanelInternal,
+              behavior: HitTestBehavior.translucent,
+              child: Container(
+                // 全透明遮罩，不阻挡背景显示 / Fully transparent overlay
+                color: Colors.transparent,
+              ),
+            ),
+          ),
+          Center(
             child: GestureDetector(
               onTap: () {},
               child: InspectorPanel(onClose: _togglePanelInternal),
             ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/src/ui/inspector_panel.dart
+++ b/lib/src/ui/inspector_panel.dart
@@ -88,7 +88,18 @@ class _InspectorPanelState extends State<InspectorPanel>
   }
 
   /// 监控开关变化 → 刷新头部状态行 / Monitor toggle → refresh header status row
-  void _onMonitorChanged() => setState(() {});
+  /// 仅在"已开启监控集合"真正变化时才重建面板，避免内存监控每 500ms 的数据
+  /// 刷新（enabled 未变）持续重建整个面板、打断趋势图手势。
+  /// Only rebuilds the panel when the set of active monitors actually changes,
+  /// so the per-500ms data ticks (enabled unchanged) don't keep rebuilding the
+  /// whole panel and interrupt trend-chart gestures.
+  String? _lastActiveMonitors;
+  void _onMonitorChanged() {
+    final current = _activeMonitors.join(',');
+    if (current == _lastActiveMonitors) return;
+    _lastActiveMonitors = current;
+    if (mounted) setState(() {});
+  }
 
   /// 当前已开启的实时监控标签 / Currently active real-time monitor labels
   List<String> get _activeMonitors {

--- a/lib/src/ui/memory_trend_chart.dart
+++ b/lib/src/ui/memory_trend_chart.dart
@@ -4,8 +4,13 @@ import 'theme/inspector_theme.dart';
 
 /// 内存趋势图组件 / Memory trend chart widget
 ///
-/// 使用 [CustomPaint] 自绘折线图，展示内存历史数据
-/// Uses [CustomPaint] to draw a custom line chart showing memory history data
+/// 使用 [CustomPaint] 自绘折线图，展示内存历史数据。
+/// Uses [CustomPaint] to draw a custom line chart showing memory history data.
+///
+/// 支持触摸交互：点击或拖动折线图区域，会显示十字准线、高亮最近的数据点，
+/// 并在顶部浮出 tooltip 显示该时刻的数值与时间。
+/// Supports touch interaction: tapping or dragging on the chart shows a crosshair,
+/// highlights the nearest data point, and pops a tooltip with the value and time.
 ///
 /// 支持的指标 / Supported metrics:
 /// - [MemoryMetric.processRss] 进程 RSS（始终可用）/ Process RSS (always available)
@@ -16,7 +21,7 @@ import 'theme/inspector_theme.dart';
 ///
 /// 当选中指标对应数据不可用时，会显示 N/A 占位说明
 /// When the data for the selected metric is unavailable, an N/A placeholder is shown
-class MemoryTrendChart extends StatelessWidget {
+class MemoryTrendChart extends StatefulWidget {
   /// 内存历史快照列表 / Memory historical snapshot list
   final List<MemorySnapshot> snapshots;
 
@@ -37,6 +42,28 @@ class MemoryTrendChart extends StatelessWidget {
     this.onMetricChanged,
     this.vmServiceAvailable = false,
   });
+
+  @override
+  State<MemoryTrendChart> createState() => _MemoryTrendChartState();
+}
+
+class _MemoryTrendChartState extends State<MemoryTrendChart> {
+  /// 当前触摸高亮的数据点索引 / Currently highlighted data point index
+  ///
+  /// 为 null 时表示未触摸，显示图例（Current / Peak / Min）
+  /// null means not touched; the legend (Current / Peak / Min) is shown instead
+  int? _touchedIndex;
+
+  /// 根据触摸位置（相对绘图区的局部 x）定位最近的数据点索引
+  /// Locate the nearest data point index from a touch x offset (local to chart)
+  int? _indexFromLocalX(double localX, double chartWidth, int pointCount) {
+    if (pointCount < 2 || chartWidth <= 0) return null;
+    final padding = _LineChartPainter.padding;
+    final usableWidth = chartWidth - padding * 2;
+    final ratio = ((localX - padding) / usableWidth).clamp(0.0, 1.0);
+    final index = (ratio * (pointCount - 1)).round();
+    return index.clamp(0, pointCount - 1);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -80,7 +107,7 @@ class MemoryTrendChart extends StatelessWidget {
         ),
         const Spacer(),
         Text(
-          '${snapshots.length}/${240}',
+          '${widget.snapshots.length}/${240}',
           style: TextStyle(
             color: InspectorColors.textHint,
             fontSize: 11,
@@ -98,14 +125,14 @@ class MemoryTrendChart extends StatelessWidget {
       runSpacing: 6,
       children: MemoryMetric.values.map((m) {
         final enabled = _isMetricEnabled(m);
-        final selected = m == metric;
+        final selected = m == widget.metric;
         return _buildMetricChip(
           label: m.label,
           selected: selected,
           enabled: enabled,
           color: m.color,
-          onTap: enabled && onMetricChanged != null
-              ? () => onMetricChanged!(m)
+          onTap: enabled && widget.onMetricChanged != null
+              ? () => widget.onMetricChanged!(m)
               : null,
         );
       }).toList(),
@@ -115,7 +142,7 @@ class MemoryTrendChart extends StatelessWidget {
   /// 检查指标是否可用 / Check if metric is enabled
   bool _isMetricEnabled(MemoryMetric m) {
     if (m == MemoryMetric.processRss) return true;
-    return vmServiceAvailable;
+    return widget.vmServiceAvailable;
   }
 
   /// 构建指标 Chip / Build metric chip
@@ -158,17 +185,17 @@ class MemoryTrendChart extends StatelessWidget {
   Widget _buildChartArea() {
     // 指标数据不可用时显示 N/A
     // Show N/A when metric data is unavailable
-    if (!_isMetricEnabled(metric)) {
+    if (!_isMetricEnabled(widget.metric)) {
       return _buildUnavailableChart();
     }
 
     // 没有数据时显示空状态
     // Show empty state when no data
-    if (snapshots.isEmpty) {
+    if (widget.snapshots.isEmpty) {
       return _buildEmptyChart();
     }
 
-    final values = snapshots.map((s) => _getValue(s)).toList();
+    final values = widget.snapshots.map((s) => _getValue(s)).toList();
     final maxValue = values.reduce((a, b) => a > b ? a : b);
     final minValue = values.reduce((a, b) => a < b ? a : b);
     final currentValue = values.last;
@@ -190,24 +217,124 @@ class MemoryTrendChart extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // 触摸高亮时的浮动 tooltip / Floating tooltip when touched
+        if (_touchedIndex != null)
+          _buildTooltip(_touchedIndex!, values)
+        else
+          // 无触摸时显示图例：Current / Peak / Min
+          // Legend: Current / Peak / Min when not touched
+          _buildLegend(currentValue, maxValue, minValue),
+        const SizedBox(height: 10),
         // 图表主体：左侧 Y 轴标签 + 中间折线图 / Chart body: left Y-axis labels + center line chart
-        // 使用 IntrinsicHeight 确保 Y 轴标签高度与折线图区域一致
-        // Use IntrinsicHeight so Y-axis labels match chart area height
-        IntrinsicHeight(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // 左侧 Y 轴标签 / Left Y-axis labels
-              SizedBox(
-                width: 52,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: yLabels
-                      .map(
-                        (label) => Padding(
-                          padding: const EdgeInsets.only(right: 6),
-                          child: Text(
+        // 注意：不要使用 IntrinsicHeight 包裹 Expanded/LayoutBuilder，否则在父级
+        // 高频重建（如开启内存监控时 InspectorPanel 每 500ms setState）时会触发
+        // `!_debugDoingThisLayout` 布局断言失败，导致面板渲染树损坏、视图消失。
+        // NOTE: do NOT wrap Expanded/LayoutBuilder in IntrinsicHeight here — it
+        // triggers a `!_debugDoingThisLayout` layout assertion when the parent
+        // rebuilds frequently (e.g. InspectorPanel setState every 500ms while
+        // memory monitoring is on), corrupting the panel render tree and making
+        // the view disappear.
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 左侧 Y 轴标签（固定高度对齐图表主体）/ Left Y-axis labels (fixed height)
+            SizedBox(
+              width: 52,
+              height: 100,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: yLabels
+                    .map(
+                      (label) => Padding(
+                        padding: const EdgeInsets.only(right: 6),
+                        child: Text(
+                          label,
+                          style: TextStyle(
+                            color: InspectorColors.textHint,
+                            fontSize: 9,
+                            fontFamily: 'monospace',
+                          ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            // 中间折线图 + 底部 X 轴标签 / Center line chart + bottom X-axis labels
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // LayoutBuilder 仅用于获取折线图实际宽度定位触摸点，
+                  // 不再置于 IntrinsicHeight 内，避免布局断言崩溃。
+                  // LayoutBuilder only measures the chart width for touch hit
+                  // testing; kept out of IntrinsicHeight to avoid layout crash.
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      final chartWidth = constraints.maxWidth;
+                      return GestureDetector(
+                        // 点击定位最近数据点 / Tap to locate nearest point
+                        onTapDown: (details) {
+                          final idx = _indexFromLocalX(
+                            details.localPosition.dx,
+                            chartWidth,
+                            values.length,
+                          );
+                          if (idx != null) {
+                            setState(() => _touchedIndex = idx);
+                          }
+                        },
+                        onTapCancel: () => setState(() => _touchedIndex = null),
+                        // 拖动实时跟手 / Drag to follow finger in real time
+                        onPanDown: (details) {
+                          final idx = _indexFromLocalX(
+                            details.localPosition.dx,
+                            chartWidth,
+                            values.length,
+                          );
+                          if (idx != null) {
+                            setState(() => _touchedIndex = idx);
+                          }
+                        },
+                        onPanUpdate: (details) {
+                          final idx = _indexFromLocalX(
+                            details.localPosition.dx,
+                            chartWidth,
+                            values.length,
+                          );
+                          if (idx != null) {
+                            setState(() => _touchedIndex = idx);
+                          }
+                        },
+                        onPanEnd: (_) => setState(() => _touchedIndex = null),
+                        child: SizedBox(
+                          height: 100,
+                          width: double.infinity,
+                          child: CustomPaint(
+                            painter: _LineChartPainter(
+                              values: values,
+                              maxValue: safeMax,
+                              lineColor: widget.metric.color,
+                              fillColor: widget.metric.color.withValues(
+                                alpha: 0.2,
+                              ),
+                              backgroundColor: InspectorColors.surface,
+                              gridColor: InspectorColors.divider,
+                              highlightIndex: _touchedIndex,
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 4),
+                  // 底部 X 轴标签 / Bottom X-axis labels
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: xLabels
+                        .map(
+                          (label) => Text(
                             label,
                             style: TextStyle(
                               color: InspectorColors.textHint,
@@ -215,75 +342,10 @@ class MemoryTrendChart extends StatelessWidget {
                               fontFamily: 'monospace',
                             ),
                           ),
-                        ),
-                      )
-                      .toList(),
-                ),
-              ),
-              // 中间折线图 + 底部 X 轴标签 / Center line chart + bottom X-axis labels
-              Expanded(
-                child: Column(
-                  children: [
-                    SizedBox(
-                      height: 100,
-                      width: double.infinity,
-                      child: CustomPaint(
-                        painter: _LineChartPainter(
-                          values: values,
-                          maxValue: safeMax,
-                          lineColor: metric.color,
-                          fillColor: metric.color.withValues(alpha: 0.2),
-                          backgroundColor: InspectorColors.surface,
-                          gridColor: InspectorColors.divider,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    // 底部 X 轴标签 / Bottom X-axis labels
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: xLabels
-                          .map(
-                            (label) => Text(
-                              label,
-                              style: TextStyle(
-                                color: InspectorColors.textHint,
-                                fontSize: 9,
-                                fontFamily: 'monospace',
-                              ),
-                            ),
-                          )
-                          .toList(),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 10),
-        // 图例：Current / Peak / Min / Legend: Current / Peak / Min
-        Row(
-          children: [
-            Expanded(
-              child: _buildChartLegend(
-                'Current',
-                _formatBytes(currentValue),
-                metric.color,
-              ),
-            ),
-            Expanded(
-              child: _buildChartLegend(
-                'Peak',
-                _formatBytes(maxValue),
-                InspectorColors.warning,
-              ),
-            ),
-            Expanded(
-              child: _buildChartLegend(
-                'Min',
-                _formatBytes(minValue),
-                InspectorColors.textSecondary,
+                        )
+                        .toList(),
+                  ),
+                ],
               ),
             ),
           ],
@@ -292,9 +354,98 @@ class MemoryTrendChart extends StatelessWidget {
     );
   }
 
+  /// 构建触摸 tooltip / Build touch tooltip
+  ///
+  /// 显示高亮点的数值与时间（相对"现在"的偏移）
+  /// Shows the highlighted point's value and time (offset from "now")
+  Widget _buildTooltip(int index, List<int> values) {
+    final snapshot = widget.snapshots[index];
+    final value = values[index];
+    final now = widget.snapshots.isNotEmpty
+        ? widget.snapshots.last.timestamp
+        : DateTime.now();
+    final delta = now.difference(snapshot.timestamp);
+    final timeLabel = delta.inSeconds <= 0
+        ? 'Now'
+        : '-${(delta.inSeconds / 60).floor()}m ${delta.inSeconds % 60}s';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 10),
+      margin: const EdgeInsets.only(bottom: 4),
+      decoration: BoxDecoration(
+        color: widget.metric.color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(
+          color: widget.metric.color.withValues(alpha: 0.4),
+          width: 0.5,
+        ),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color: widget.metric.color,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            _formatBytes(value),
+            style: TextStyle(
+              color: widget.metric.color,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              fontFamily: 'monospace',
+            ),
+          ),
+          const Spacer(),
+          Text(
+            timeLabel,
+            style: TextStyle(
+              color: InspectorColors.textHint,
+              fontSize: 11,
+              fontFamily: 'monospace',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 构建图例项组 / Build legend group
+  Widget _buildLegend(int currentValue, int maxValue, int minValue) {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildChartLegend(
+            'Current',
+            _formatBytes(currentValue),
+            widget.metric.color,
+          ),
+        ),
+        Expanded(
+          child: _buildChartLegend(
+            'Peak',
+            _formatBytes(maxValue),
+            InspectorColors.warning,
+          ),
+        ),
+        Expanded(
+          child: _buildChartLegend(
+            'Min',
+            _formatBytes(minValue),
+            InspectorColors.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+
   /// 获取快照对应指标的值 / Get the value of the metric for the snapshot
   int _getValue(MemorySnapshot s) {
-    switch (metric) {
+    switch (widget.metric) {
       case MemoryMetric.processRss:
         return s.processRss;
       case MemoryMetric.heapUsage:
@@ -463,8 +614,11 @@ class _LineChartPainter extends CustomPainter {
   /// 网格线颜色 / Grid line color
   final Color gridColor;
 
+  /// 高亮数据点的索引；为 null 时不绘制十字准线 / Highlighted point index; null disables crosshair
+  final int? highlightIndex;
+
   /// 内边距（图表距离画布边缘）/ Padding (chart to canvas edge)
-  static const double _padding = 4.0;
+  static const double padding = 4.0;
 
   /// 网格水平线数量 / Number of horizontal grid lines
   static const int _gridLineCount = 4;
@@ -476,6 +630,7 @@ class _LineChartPainter extends CustomPainter {
     required this.fillColor,
     required this.backgroundColor,
     required this.gridColor,
+    this.highlightIndex,
   });
 
   @override
@@ -498,12 +653,12 @@ class _LineChartPainter extends CustomPainter {
       ..strokeWidth = 0.5
       ..style = PaintingStyle.stroke;
 
-    final chartHeight = size.height - _padding * 2;
+    final chartHeight = size.height - padding * 2;
     for (var i = 0; i <= _gridLineCount; i++) {
-      final y = _padding + (chartHeight / _gridLineCount) * i;
+      final y = padding + (chartHeight / _gridLineCount) * i;
       canvas.drawLine(
-        Offset(_padding, y),
-        Offset(size.width - _padding, y),
+        Offset(padding, y),
+        Offset(size.width - padding, y),
         gridPaint,
       );
     }
@@ -516,7 +671,7 @@ class _LineChartPainter extends CustomPainter {
       if (values.isNotEmpty) {
         final x = size.width / 2;
         final normalized = maxValue > 0 ? values.first / maxValue : 0.0;
-        final y = size.height - _padding - (chartHeight * normalized);
+        final y = size.height - padding - (chartHeight * normalized);
 
         final dotPaint = Paint()..color = lineColor;
         canvas.drawCircle(Offset(x, y), 2, dotPaint);
@@ -526,25 +681,25 @@ class _LineChartPainter extends CustomPainter {
 
     // 4. 计算每个数据点的坐标
     // 4. Calculate coordinates for each data point
-    final chartWidth = size.width - _padding * 2;
+    final chartWidth = size.width - padding * 2;
     final stepX = chartWidth / (values.length - 1);
 
     final points = <Offset>[];
     for (var i = 0; i < values.length; i++) {
-      final x = _padding + stepX * i;
+      final x = padding + stepX * i;
       final normalized = maxValue > 0 ? values[i] / maxValue : 0.0;
       // 留 5% 顶部空间避免折线贴边
       // Leave 5% top space to avoid line touching the edge
-      final y = size.height - _padding - (chartHeight * 0.95 * normalized);
+      final y = size.height - padding - (chartHeight * 0.95 * normalized);
       points.add(Offset(x, y));
     }
 
     // 5. 绘制填充区域（折线下方）
     // 5. Draw fill area (below the line)
     final fillPath = Path()
-      ..moveTo(points.first.dx, size.height - _padding)
+      ..moveTo(points.first.dx, size.height - padding)
       ..addPoints(points.map((p) => Offset(p.dx, p.dy)).toList())
-      ..lineTo(points.last.dx, size.height - _padding)
+      ..lineTo(points.last.dx, size.height - padding)
       ..close();
 
     final fillPaint = Paint()
@@ -573,6 +728,37 @@ class _LineChartPainter extends CustomPainter {
       ..color = lineColor.withValues(alpha: 0.3)
       ..style = PaintingStyle.fill;
     canvas.drawCircle(lastPoint, 5, ringPaint);
+
+    // 8. 触摸高亮：十字准线 + 选中点圈
+    // 8. Touch highlight: crosshair + highlighted point ring
+    if (highlightIndex != null &&
+        highlightIndex! >= 0 &&
+        highlightIndex! < points.length) {
+      final hp = points[highlightIndex!];
+      // 竖向准线 / Vertical crosshair line
+      final crossPaint = Paint()
+        ..color = lineColor.withValues(alpha: 0.35)
+        ..strokeWidth = 0.5
+        ..style = PaintingStyle.stroke;
+      canvas.drawLine(
+        Offset(hp.dx, padding),
+        Offset(hp.dx, size.height - padding),
+        crossPaint,
+      );
+      // 横向准线 / Horizontal crosshair line
+      canvas.drawLine(
+        Offset(padding, hp.dy),
+        Offset(size.width - padding, hp.dy),
+        crossPaint,
+      );
+      // 选中点：外圈 + 实心点 / Highlighted point: outer ring + solid dot
+      final highlightRing = Paint()
+        ..color = lineColor.withValues(alpha: 0.25)
+        ..style = PaintingStyle.fill;
+      canvas.drawCircle(hp, 7, highlightRing);
+      final highlightDot = Paint()..color = lineColor;
+      canvas.drawCircle(hp, 3.5, highlightDot);
+    }
   }
 
   @override
@@ -582,7 +768,8 @@ class _LineChartPainter extends CustomPainter {
     return oldDelegate.values != values ||
         oldDelegate.maxValue != maxValue ||
         oldDelegate.lineColor != lineColor ||
-        oldDelegate.fillColor != fillColor;
+        oldDelegate.fillColor != fillColor ||
+        oldDelegate.highlightIndex != highlightIndex;
   }
 }
 

--- a/lib/zero_inspector_kit.dart
+++ b/lib/zero_inspector_kit.dart
@@ -362,21 +362,42 @@ class _InspectorAppWrapperState extends State<_InspectorAppWrapper> {
   }
 
   /// 构建面板内容 / Build panel content
+  ///
+  /// 采用分层结构避免"点背景关闭"被误触发：
+  /// - 底层：覆盖全屏的透明 GestureDetector（onTap: 关闭面板）
+  /// - 上层：居中面板内容，内部 GestureDetector(onTap: (){}) 消费点击，
+  ///   因此点击面板本身不会冒泡到底层关闭层。
+  /// 原先的单层 GestureDetector(HitTestBehavior.opaque) 会在 InspectorPanel
+  /// 因 MemoryInspectorService 高频 notifyListeners 而重建时，被 Flutter
+  /// 重新派发的合成指针事件命中，导致开启内存监控后面板被自动关闭。
+  /// Uses a layered structure to avoid the "tap background to close" being
+  /// misfired: a full-screen background layer closes the panel on tap, while the
+  /// centered panel content sits on top and consumes taps (onTap: (){}) so
+  /// tapping the panel itself never bubbles to the close layer. The previous
+  /// single opaque GestureDetector was occasionally hit by a synthetic pointer
+  /// event when InspectorPanel rebuilt from MemoryInspectorService's frequent
+  /// notifications, auto-closing the panel right after enabling memory monitor.
   Widget _buildPanelContent() {
-    return GestureDetector(
-      onTap: _togglePanel,
-      behavior: HitTestBehavior.opaque,
-      child: Container(
-        // 全透明遮罩，不阻挡背景显示
-        // Fully transparent overlay
-        color: Colors.transparent,
-        child: Center(
+    return Stack(
+      children: [
+        // 关闭层：点击空白区域关闭面板
+        // Close layer: tapping empty area closes the panel
+        Positioned.fill(
+          child: GestureDetector(
+            onTap: _togglePanel,
+            behavior: HitTestBehavior.translucent,
+            child: Container(color: Colors.transparent),
+          ),
+        ),
+        // 面板内容层：在关闭层之上，点击面板内部不关闭
+        // Panel content layer: above the close layer; tapping inside is consumed
+        Center(
           child: GestureDetector(
             onTap: () {},
             child: InspectorPanel(onClose: _togglePanel),
           ),
         ),
-      ),
+      ],
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zero_inspector_kit
 description: A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.
-version: 1.3.5
+version: 1.3.6
 homepage: https://github.com/zero-labsco/zero_inspector_kit
 repository: https://github.com/zero-labsco/zero_inspector_kit
 documentation: https://zero-labsco.github.io/zero_inspector_kit/


### PR DESCRIPTION
### Summary / 摘要

Memory trend chart now supports tap/drag touch interaction with a crosshair and tooltip, and the panel no longer auto-closes when enabling the memory monitor.
内存趋势图新增点击/拖动触摸交互（十字准线 + Tooltip），并修复开启内存监控后面板被自动关闭的问题。

### Changes / 变更

- Memory trend chart: tap/drag highlights the nearest data point with a crosshair and a floating tooltip (value + time offset from now); 4 switchable metrics (RSS / Heap / New / Old); Current/Peak/Min legend kept when untouched / 内存趋势图：点击/拖动高亮最近数据点，绘制十字准线与浮动 Tooltip（数值 + 相对时间）；4 个可切换指标；未触摸时保留 Current/Peak/Min 图例
- Fix panel auto-close after enabling memory monitor: split the background close layer from the panel content layer (Stack + translucent) so synthetic pointer events no longer misfire the close / 修复开启内存监控后面板自动关闭：将背景关闭层与面板内容层分离（Stack + translucent），避免合成指针事件误触关闭
- Avoid rebuilding the whole panel on every 500ms data tick by only rebuilding when the active-monitor set actually changes / 仅在已开启监控集合真正变化时重建面板，避免每 500ms 数据刷新持续重建、打断趋势图手势
- Bump version to 1.3.6 and sync README / README_zh / CHANGELOG / docs/Installation / ios podspec / example lock / 版本升至 1.3.6，并同步 README、README_zh、CHANGELOG、docs/Installation、iOS podspec 与 example lock

### Context / 背景

The memory trend chart needed a way to inspect historical points, but the touch interaction initially caused a layout assertion crash and, combined with high-frequency memory notifications, made the panel auto-close. This PR delivers the interaction and hardens the panel lifecycle.
内存趋势图需要能回溯历史数据点；但交互改动最初引发了布局断言崩溃，且与内存高频通知叠加时导致面板自动关闭。本 PR 交付交互能力并加固面板生命周期。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [x] Enable memory monitor, tap/drag the trend chart to see the crosshair + tooltip, and confirm the panel stays open / 开启内存监控，点击/拖动趋势图查看十字准线与 Tooltip，并确认面板不会自动关闭
- [x] Verify flutter analyze / flutter test are green in CI / 确认 CI 中 flutter analyze 与 flutter test 通过

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
