### PR TITLE
fix: await _calculateDirSize and bump to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.4.1
+
+> **🛠 Fixes / 修复:** 修复 `MemoryInspectorService.getDocumentsDirSize` 与 `getCacheDirSize` 中 `return _calculateDirSize(dir)` 未 `await` 导致的 `unawaited_return_in_try_block` 分析告警。改用 `final size = await _calculateDirSize(dir); return size;`,使 `try` 块的异常捕获能正确覆盖目录大小计算中的异步错误。无新增公共 API,向后兼容。
+> Fixes the `unawaited_return_in_try_block` analysis warning in `MemoryInspectorService.getDocumentsDirSize` and `getCacheDirSize`, where `return _calculateDirSize(dir)` was not awaited. Now `final size = await _calculateDirSize(dir); return size;`, so the `try` block's exception handling correctly covers async errors during directory-size calculation. No new public API; backward compatible.
+
+- 修复 / Fix
+  - `getDocumentsDirSize` / `getCacheDirSize` 先 `await` 计算结果再 `return`,消除 `unawaited_return_in_try_block` 告警
+  - `getDocumentsDirSize` / `getCacheDirSize` now `await` the result before `return`, removing the `unawaited_return_in_try_block` warning
+
 ## 1.4.0
 
 > **🧭 路由追踪穿透 / Route-observer penetration:** `ZeroInspectorKit.runAppWithInspector` 现在能穿透包裹根组件的轻量壳（如 `StatelessWidget` / `Container` / `Builder` / `Padding` / `Center` / `SizedBox` 等），找到内部的 `MaterialApp` 并自动注入 `InspectorRouteObserver`，无需把 `MaterialApp` 直接作为根传入即可启用路由追踪。遇到不可穿透的组件（如 `StatefulWidget` 壳）时安全回退到外层包裹模式。无新增公共 API。

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful Flutter plugin for in-app developer console, providing real-time debu
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 Upgrade recommended:** v1.4.0 extends the inspector with two additions — **route-observer penetration for wrapped apps** (when your root widget is a shell like `StatelessWidget` / `Container` / `Builder` / `Padding` / `Center` wrapping the real `MaterialApp`, the inspector drills through the shell, finds the inner `MaterialApp`, and auto-injects `InspectorRouteObserver` so route tracking works without manual wiring) and **richer network filters** (an expandable filter panel in the network viewer to filter by HTTP Method, status code, and interception status). All users are advised to upgrade to `^1.4.0`.
+> **🔔 Upgrade recommended:** v1.4.1 fixes the `unawaited_return_in_try_block` analysis warning in `MemoryInspectorService` (no breaking changes). It builds on v1.4.0, which extends the inspector with two additions — **route-observer penetration for wrapped apps** (when your root widget is a shell like `StatelessWidget` / `Container` / `Builder` / `Padding` / `Center` wrapping the real `MaterialApp`, the inspector drills through the shell, finds the inner `MaterialApp`, and auto-injects `InspectorRouteObserver` so route tracking works without manual wiring) and **richer network filters** (an expandable filter panel in the network viewer to filter by HTTP Method, status code, and interception status). All users are advised to upgrade to `^1.4.1`.
 
 🌐 **[Official Website](https://www.zerolabsco.com/)**
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.4.0
+  zero_inspector_kit: ^1.4.1
 ```
 
 ### GitHub
 
-Alternatively, you can install from GitHub (replace `1.4.0` with the version you need):
+Alternatively, you can install from GitHub (replace `1.4.1` with the version you need):
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: release/v1.4.0
+      ref: release/v1.4.1
 ```
 
 ## Usage

--- a/README_zh.md
+++ b/README_zh.md
@@ -40,19 +40,19 @@
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.4.0
+  zero_inspector_kit: ^1.4.1
 ```
 
 ### GitHub
 
-或者，你也可以从 GitHub 安装（将 `1.4.0` 替换为你需要的版本号）：
+或者，你也可以从 GitHub 安装（将 `1.4.1` 替换为你需要的版本号）：
 
 ```yaml
 dependencies:
   zero_inspector_kit:
     git:
       url: https://github.com/zero-labsco/zero_inspector_kit.git
-      ref: release/v1.4.0
+      ref: release/v1.4.1
 ```
 
 ## 使用方法

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,7 @@
 [![Dart](https://img.shields.io/badge/Dart-✓-0175C2?logo=dart)](https://dart.dev)
 [![Style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)
 
-> **🔔 推荐升级：** v1.4.0 为检查器带来两项新增 —— **路由追踪穿透**（当根组件是包裹壳，如 `StatelessWidget` / `Container` / `Builder` / `Padding` / `Center` 包着真正的 `MaterialApp` 时，检查器会穿透壳、定位内部 `MaterialApp` 并自动注入 `InspectorRouteObserver`，无需把 `MaterialApp` 直接作为根传入即可启用路由追踪）与**更丰富的网络筛选**（网络查看器新增可展开筛选面板，可按 HTTP Method、状态码区间、拦截状态筛选）。建议所有用户升级到 `^1.4.0`。
+> **🔔 推荐升级：** v1.4.1 修复了 `MemoryInspectorService` 中的 `unawaited_return_in_try_block` 分析告警（无破坏性变更）。它基于 v1.4.0 —— 该版本为检查器带来两项新增 —— **路由追踪穿透**（当根组件是包裹壳，如 `StatelessWidget` / `Container` / `Builder` / `Padding` / `Center` 包着真正的 `MaterialApp` 时，检查器会穿透壳、定位内部 `MaterialApp` 并自动注入 `InspectorRouteObserver`，无需把 `MaterialApp` 直接作为根传入即可启用路由追踪）与**更丰富的网络筛选**（网络查看器新增可展开筛选面板，可按 HTTP Method、状态码区间、拦截状态筛选）。建议所有用户升级到 `^1.4.1`。
 
 🌐 **[官方网站](https://www.zerolabsco.com/)**
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,7 +8,7 @@ Add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  zero_inspector_kit: ^1.4.0
+  zero_inspector_kit: ^1.4.1
 ```
 
 Then run:

--- a/ios/zero_inspector_kit.podspec
+++ b/ios/zero_inspector_kit.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'zero_inspector_kit'
-  s.version          = '1.4.0'
+  s.version          = '1.4.1'
   s.summary          = 'A Flutter plugin for in-app developer console.'
   s.description      = <<-DESC
 A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.

--- a/lib/src/services/memory_inspector_service.dart
+++ b/lib/src/services/memory_inspector_service.dart
@@ -1244,7 +1244,8 @@ class MemoryInspectorService extends ChangeNotifier {
   Future<int> getDocumentsDirSize() async {
     try {
       final dir = await getApplicationDocumentsDirectory();
-      return _calculateDirSize(dir);
+      final size = await _calculateDirSize(dir);
+      return size;
     } catch (_) {
       return 0;
     }
@@ -1254,7 +1255,8 @@ class MemoryInspectorService extends ChangeNotifier {
   Future<int> getCacheDirSize() async {
     try {
       final dir = await getTemporaryDirectory();
-      return _calculateDirSize(dir);
+      final size = await _calculateDirSize(dir);
+      return size;
     } catch (_) {
       return 0;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zero_inspector_kit
 description: A Flutter plugin for in-app developer console with network request viewing, logging, database inspection, memory monitoring, FPS monitoring, and route tracking.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/zero-labsco/zero_inspector_kit
 repository: https://github.com/zero-labsco/zero_inspector_kit
 documentation: https://zero-labsco.github.io/zero_inspector_kit/


### PR DESCRIPTION
### Summary / 摘要

Resolve the `unawaited_return_in_try_block` analysis warning in `MemoryInspectorService` and release as 1.4.1. / 修复 `MemoryInspectorService` 中的 `unawaited_return_in_try_block` 分析告警,并发布为 1.4.1。

### Changes / 变更

- Await `_calculateDirSize` before returning in `getDocumentsDirSize` / `getCacheDirSize` so the `try` block correctly covers async errors / 在 `getDocumentsDirSize` / `getCacheDirSize` 中先 `await` 再 `return`,使 `try` 块能正确捕获异步错误
- Bump version to 1.4.1 (pubspec, CHANGELOG, README, README_zh, docs/Installation) / 版本升至 1.4.1(pubspec、CHANGELOG、README、README_zh、docs/Installation)
- Update README upgrade note to recommend `^1.4.1` / 更新 README 升级提示为推荐 `^1.4.1`

### Context / 背景

pub.dev reported two `unawaited_return_in_try_block` warnings when publishing 1.4.0. They are non-blocking but should be fixed for clean analysis. / 发布 1.4.0 时 pub.dev 报了两处 `unawaited_return_in_try_block` 告警,虽不阻断发布但应修复以保证分析干净。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [x] `dart analyze` shows no `unawaited` warnings / dart analyze 无 unawaited 告警
- [x] `dart format --set-exit-if-changed lib/` → 0 changed / 格式化幂等

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
