### PR TITLE
fix: disable Jekyll on GitHub Pages so _next assets are served

### DIFF
--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -121,6 +121,11 @@ function syncOutToDocs() {
     rmSync(join(docsDir, entry), { recursive: true, force: true });
   }
   cpSync(outDir, docsDir, { recursive: true });
+  // GitHub Pages runs Jekyll by default, which silently drops any file or
+  // directory whose name begins with an underscore (e.g. _next, _meta). That
+  // strips all CSS/JS from the static export and leaves the site unstyled.
+  // An empty .nojekyll disables Jekyll so the build is served verbatim.
+  writeFileSync(join(docsDir, '.nojekyll'), '');
 }
 
 function main() {


### PR DESCRIPTION
GitHub Pages runs Jekyll by default, which silently drops underscore-prefixed paths such as docs/_next and docs/_meta, stripping all CSS/JS and leaving the docs site unstyled. Add docs/.nojekyll to disable Jekyll, and have sync-docs.mjs generate it automatically after each build so future rebuilds keep serving assets.