### PR TITLE
feat: scriptize pre-commit hook install via npm run setup-hook

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next build"
+    "export": "next build",
+    "setup-hook": "node scripts/install-hook.mjs"
   },
   "dependencies": {
     "next": "14.2.15",

--- a/website/scripts/install-hook.mjs
+++ b/website/scripts/install-hook.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * install-hook.mjs
+ *
+ * Installs the Nextra pre-commit hook into the local git repository.
+ * Run via `npm run setup-hook` (or `node website/scripts/install-hook.mjs`).
+ *
+ * It copies website/scripts/pre-commit (the tracked template) to
+ * .git/hooks/pre-commit and makes it executable, so that committing
+ * automatically builds & syncs the documentation site.
+ *
+ * Safe to run repeatedly. Does nothing destructive.
+ */
+
+import {
+  copyFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '..', '..');
+const template = join(scriptDir, 'pre-commit');
+const hooksDir = join(repoRoot, '.git', 'hooks');
+const target = join(hooksDir, 'pre-commit');
+
+if (!existsSync(template)) {
+  console.error('[install-hook] Missing hook template:', template);
+  process.exit(1);
+}
+
+mkdirSync(hooksDir, { recursive: true });
+copyFileSync(template, target);
+
+// Make executable on POSIX; on Windows the .sh is run by git's shell, chmod is a no-op-safe call.
+try {
+  chmodSync(target, 0o755);
+} catch {}
+
+// Verify git can find the hook path (basic sanity).
+try {
+  execSync('git rev-parse --git-dir', { cwd: repoRoot, stdio: 'pipe' });
+} catch {
+  console.error('[install-hook] Not inside a git repository?');
+  process.exit(1);
+}
+
+console.log('[install-hook] Pre-commit hook installed at .git/hooks/pre-commit');
+console.log('[install-hook] It will build & sync the docs site on relevant commits.');

--- a/website/scripts/pre-commit
+++ b/website/scripts/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Pre-commit hook template for zero_inspector_kit.
+#
+# Installed into .git/hooks/pre-commit by `npm run setup-hook`
+# (see website/scripts/install-hook.mjs). It is NOT tracked in .git/
+# directly, so this template file is the source of truth.
+#
+# On commit, it runs sync-docs.mjs which:
+#   - detects whether website/ source or pubspec.yaml version changed
+#   - injects the package version (from pubspec.yaml) into website/pages/*.md
+#   - builds the Nextra site (website/out/)
+#   - syncs website/out/ -> docs/ and stages it
+# If nothing changed, it exits 0 immediately (no build).
+
+root="$(git rev-parse --show-toplevel)"
+node "$root/website/scripts/sync-docs.mjs"


### PR DESCRIPTION
Add website/scripts/pre-commit (the tracked hook template) and website/scripts/install-hook.mjs, plus a setup-hook npm script. After cloning, running 'cd website && npm install && npm run setup-hook' installs the hook into .git/hooks so commits auto-build and sync the docs site. This keeps the hook source in the repo instead of relying on a local-only .git/hooks file.