### PR TITLE
ci: build example ios simulator archive and upload as artifact

### DIFF
--- a/.github/workflows/example-ios-build.yml
+++ b/.github/workflows/example-ios-build.yml
@@ -62,4 +62,18 @@ jobs:
         # This compiles the example AND the plugin's native Swift, surfacing errors
         # (e.g. availableData / vm_info) that only newer Xcode toolchains flag.
         working-directory: example
-        run: flutter build ios --simulator
+        run: flutter build ios --simulator --no-codesign
+
+      - name: Create iOS simulator archive
+        # 打包模拟器 .app 为 zip，供 Appetize 等云端 iOS 模拟器使用（Appetize 要求 zip 根目录直接包含 .app）。
+        # Package the simulator .app as a zip for cloud iOS simulators like Appetize
+        # (Appetize requires the zip to contain the .app at its root).
+        working-directory: example/build/ios/iphonesimulator
+        run: |
+          zip -r ../../../../zero_inspector_kit_example_simulator.zip Runner.app
+
+      - name: Upload iOS simulator build
+        uses: actions/upload-artifact@v5
+        with:
+          name: ios-simulator-build
+          path: zero_inspector_kit_example_simulator.zip


### PR DESCRIPTION
### Summary / 摘要

Pack the example app's iOS simulator build into a zip artifact so it can be used by cloud iOS simulators such as Appetize.
将示例应用的 iOS 模拟器构建打包为 zip 产物，供 Appetize 等云端 iOS 模拟器使用。

### Changes / 变更

- Added `--no-codesign` to the `flutter build ios --simulator` step so the build does not require a signing identity in CI. / 在 `flutter build ios --simulator` 步骤加上 `--no-codesign`，使 CI 构建无需签名证书。
- Added a step that zips `Runner.app` (with the `.app` at the zip root, as Appetize requires) into `zero_inspector_kit_example_simulator.zip`. / 新增步骤将 `Runner.app` 打包为 zip（Appetize 要求 .app 位于 zip 根目录）。
- Uploaded the zip as the `ios-simulator-build` artifact via `actions/upload-artifact@v5`. / 通过 `actions/upload-artifact@v5` 将 zip 上传为 `ios-simulator-build` 产物。

### Context / 背景

The example iOS build previously only compiled to verify the plugin's native Swift. Packaging it as a simulator zip lets reviewers/demos run the example on a cloud iOS simulator (e.g. Appetize) without a local Mac.
示例的 iOS 构建此前仅用于编译校验插件的原生 Swift。打包成模拟器 zip 后，评审或演示可在云端 iOS 模拟器（如 Appetize）直接运行示例，无需本地 Mac。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [x] Confirm the `example-ios-build` workflow produces the `ios-simulator-build` artifact containing `Runner.app` at the zip root. / 确认 `example-ios-build` 工作流产出 `ios-simulator-build` 产物，且 zip 根目录含 `Runner.app`。

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
