### PR TITLE
docs: render README screenshots on pub.dev via absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,19 @@ A powerful Flutter plugin for an in-app developer console, providing real-time d
 
 | Network Inspector | Database Viewer |
 | --- | --- |
-| <a href="image/screenshot/network.png"><img src="image/screenshot/network.png" width="240" alt="Network Inspector" /></a> | <a href="image/screenshot/database.png"><img src="image/screenshot/database.png" width="240" alt="Database Viewer" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/network.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/network.png" width="240" alt="Network Inspector" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/database.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/database.png" width="240" alt="Database Viewer" /></a> |
 
 | Logging | Memory Monitor |
 | --- | --- |
-| <a href="image/screenshot/logs.png"><img src="image/screenshot/logs.png" width="240" alt="Logging" /></a> | <a href="image/screenshot/memory.png"><img src="image/screenshot/memory.png" width="240" alt="Memory Monitor" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/logs.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/logs.png" width="240" alt="Logging" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/memory.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/memory.png" width="240" alt="Memory Monitor" /></a> |
 
 | FPS Monitor | Route Tracker |
 | --- | --- |
-| <a href="image/screenshot/fps.png"><img src="image/screenshot/fps.png" width="240" alt="FPS Monitor" /></a> | <a href="image/screenshot/routes.png"><img src="image/screenshot/routes.png" width="240" alt="Route Tracker" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/fps.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/fps.png" width="240" alt="FPS Monitor" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/routes.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/routes.png" width="240" alt="Route Tracker" /></a> |
 
 | Alerts | Widget Inspector |
 | --- | --- |
-| <a href="image/screenshot/alerts.png"><img src="image/screenshot/alerts.png" width="240" alt="Alerts" /></a> | <a href="image/screenshot/widgets.png"><img src="image/screenshot/widgets.png" width="240" alt="Widget Inspector" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/alerts.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/alerts.png" width="240" alt="Alerts" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/widgets.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/widgets.png" width="240" alt="Widget Inspector" /></a> |
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,19 +69,19 @@
 
 | 网络检查器 | 数据库查看器 |
 | --- | --- |
-| <a href="image/screenshot/network.png"><img src="image/screenshot/network.png" width="240" alt="网络检查器" /></a> | <a href="image/screenshot/database.png"><img src="image/screenshot/database.png" width="240" alt="数据库查看器" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/network.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/network.png" width="240" alt="网络检查器" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/database.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/database.png" width="240" alt="数据库查看器" /></a> |
 
 | 日志记录 | 内存监控 |
 | --- | --- |
-| <a href="image/screenshot/logs.png"><img src="image/screenshot/logs.png" width="240" alt="日志记录" /></a> | <a href="image/screenshot/memory.png"><img src="image/screenshot/memory.png" width="240" alt="内存监控" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/logs.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/logs.png" width="240" alt="日志记录" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/memory.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/memory.png" width="240" alt="内存监控" /></a> |
 
 | FPS 监控 | 路由追踪器 |
 | --- | --- |
-| <a href="image/screenshot/fps.png"><img src="image/screenshot/fps.png" width="240" alt="FPS 监控" /></a> | <a href="image/screenshot/routes.png"><img src="image/screenshot/routes.png" width="240" alt="路由追踪器" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/fps.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/fps.png" width="240" alt="FPS 监控" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/routes.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/routes.png" width="240" alt="路由追踪器" /></a> |
 
 | 告警系统 | Widget 检查器 |
 | --- | --- |
-| <a href="image/screenshot/alerts.png"><img src="image/screenshot/alerts.png" width="240" alt="告警系统" /></a> | <a href="image/screenshot/widgets.png"><img src="image/screenshot/widgets.png" width="240" alt="Widget 检查器" /></a> |
+| <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/alerts.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/alerts.png" width="240" alt="告警系统" /></a> | <a href="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/widgets.png"><img src="https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/widgets.png" width="240" alt="Widget 检查器" /></a> |
 
 ---
 


### PR DESCRIPTION
### Summary / 摘要

Replace local repo-relative screenshot paths in the README with absolute raw.githubusercontent.com URLs so thumbnails render on the pub.dev package page. / 将 README 中的截图相对路径改为绝对 raw.githubusercontent.com URL，使其在 pub.dev 包页面正常显示。

### Changes / 变更

- Switch README.md and README_zh.md screenshot `<img>` / `<a href>` sources from `image/screenshot/*.png` to absolute `https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/*.png` (8 images). / 将 README.md 与 README_zh.md 的 8 张截图 `<img>`/`<a href>` 源从 `image/screenshot/*.png` 改为绝对 URL `https://raw.githubusercontent.com/zero-labsco/zero_inspector_kit/main/image/screenshot/*.png`。

### Context / 背景

pub.dev does not reliably render README images referenced by local repo-relative paths; absolute URLs fix the broken thumbnails on the package page. This is a docs-only change and will take effect on pub.dev at the next publish. / pub.dev 无法稳定渲染以仓库相对路径引用的 README 图片；使用绝对 URL 可修复包页面缩略图不显示的问题。本次为纯文档改动，将在下次发布时于 pub.dev 生效。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [x] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [ ] Open the PR's README preview and confirm all 8 thumbnails load; verify on the pub.dev package page after the next publish. / 打开 PR 的 README 预览确认 8 张缩略图均可加载；下次发布后于 pub.dev 包页面复核。

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
