### PR TITLE
fix: remove non-existent labels from dependabot.yml 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,6 @@ updates:
     # 版本约束策略：保留既有 caret(^) 风格，仅提升版本号 / Preserve caret style, bump version only
     versioning-strategy: "increase"
     labels:
-      - "dependencies"
       - "pub"
     commit-message:
       prefix: "chore(deps)"
@@ -82,7 +81,6 @@ updates:
     # 与根项目一致：保留 caret 约束 / Same as root: preserve caret constraints
     versioning-strategy: "increase"
     labels:
-      - "dependencies"
       - "pub"
       - "example"
     commit-message:
@@ -104,9 +102,6 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "chore(ci)"
       include: "scope"


### PR DESCRIPTION
### Summary / 摘要

Remove Dependabot label entries that point to non-existent repo labels, fixing the Dependabot config error.
移除 dependabot.yml 中引用了仓库里不存在的标签的配置项，修复 Dependabot 报错。

### Changes / 变更

- Drop the `dependencies` and `github-actions` labels from `.github/dependabot.yml` (kept real `pub`/`example` labels). / 删除 `.github/dependabot.yml` 里的 `dependencies` 与 `github-actions` 标签（保留真实存在的 `pub`、`example`）。

### Context / 背景

Dependabot errored because the config referenced `dependencies` and `github-actions` labels that do not exist in the repository. Removing the invalid entries resolves the error; PR title checks are unaffected since Dependabot PR titles already follow Conventional Commits.
Dependabot 报错的原因是配置引用了仓库中不存在的 `dependencies` 和 `github-actions` 标签。移除无效项即可修复；PR 标题检查不受影响，因为 Dependabot 的 PR 标题本就遵循约定式提交。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [ ] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [ ] Verify Dependabot no longer errors on the next scheduled run / 在下一次定时运行时确认 Dependabot 不再报错

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
