### PR TITLE
fix: use valid dependency-type values inside dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,14 +17,14 @@ updates:
       # 运行时依赖（http、sqflite 等）的 minor/patch 合并到一个 PR
       # Runtime deps (http, sqflite, ...) minor/patch grouped into one PR
       pub-runtime:
-        dependency-type: "direct:production"
+        dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
       # 开发依赖（flutter_lints 等）单独一组，更新频率与风险不同
       # Dev deps (flutter_lints, ...) in their own group
       pub-dev:
-        dependency-type: "direct:development"
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
@@ -61,13 +61,13 @@ updates:
     groups:
       # example 运行时依赖 minor/patch 合并 / Example runtime deps minor/patch grouped
       example-runtime:
-        dependency-type: "direct:production"
+        dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
       # example 开发依赖单独一组 / Example dev deps in own group
       example-dev:
-        dependency-type: "direct:development"
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
### Summary / 摘要

Replace the unsupported `direct:` prefixed `dependency-type` values inside Dependabot groups with the valid `production`/`development` values, fixing the config validation error.
将 Dependabot groups 中不被支持的带 `direct:` 前缀的 `dependency-type` 改为合法的 `production`/`development`，修复配置校验报错。

### Changes / 变更

- Changed `direct:production` → `production` and `direct:development` → `development` in the four group blocks (`pub-runtime`, `pub-dev`, `example-runtime`, `example-dev`). / 在四个分组（`pub-runtime`、`pub-dev`、`example-runtime`、`example-dev`）中将 `direct:production` 改为 `production`、`direct:development` 改为 `development`。

### Context / 背景

Dependabot's `groups` block only accepts `production`/`development` for `dependency-type`; the `direct:` prefixed form is valid only at the top-level `update` config, not inside groups. This raised a config-validation error on every scheduled run. The fix keeps the original grouping design (runtime vs dev deps split, majors standalone) intact.
Dependabot 的 `groups` 块里 `dependency-type` 只接受 `production`/`development`；带 `direct:` 前缀的写法仅在 `update` 顶层合法，不能在 groups 内使用，导致每次定时运行都报配置校验错误。本次修正保留了原先的分组设计（运行时/开发依赖拆分、大版本单独 PR）。

### Checklist / 检查项

- [x] Title follows Conventional Commits / 标题符合约定式提交
- [ ] CI checks pass after merge / 合入后 CI 通过

## Test plan

- [ ] Verify Dependabot no longer reports a config error on the next scheduled run / 下一次定时运行时确认 Dependabot 不再报配置错误

🤖 Generated with [Zero Buddy](https://www.zerolabsco.com)
